### PR TITLE
Add coop.se scraping for store-specific Coop stores

### DIFF
--- a/deals.json
+++ b/deals.json
@@ -7,47 +7,27 @@
     "description": "132-184 g | Gäller: XL Cookies, Home style, Choko Moment, Choco Whoopies, Brownie, Brookie | Marabou | Jfr pris 135:87-189:39/kg | Ord.pris 36:90-39:90 kr.",
     "ord_pris": "36:90-39:90",
     "jfr_pris": "135:87-189:39",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F32501a3f6b3c222b6c2766b1af192064&w=288&s=dc88d9b75a5b2378dc2576724b685d17"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F32501a3f6b3c222b6c2766b1af192064&w=572&s=23e1a5ffb47c8e887318035eb6e2f79f"
   },
   {
     "store": "ICA Supermarket",
-    "name": "Röda kärnfria druvor i ask",
+    "name": "Levainbröd",
     "price": "30:-",
     "unit": "/st",
-    "description": "500 g | Klass 1 | ICA | Jfr pris 60:00/kg | Ord.pris 49:90 kr.",
-    "ord_pris": "49:90",
-    "jfr_pris": "60:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F13e970b11f58bed03a7aff22ca8e2655&w=276&s=1b2a2c4b201a8aec2084577895c76ebd"
+    "description": "650 g | Gäller råg- och vetelevain | Pågen | Jfr pris 46:15/kg | Ord.pris 44:90 kr.",
+    "ord_pris": "44:90",
+    "jfr_pris": "46:15",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdf64e3e6b34ee3524573b8150f4ca20b&w=276&s=e1ea902cea9a6ca840eddbf4cddb80f5"
   },
   {
     "store": "ICA Supermarket",
-    "name": "Tulpaner 12-pack",
-    "price": "99:-",
-    "unit": "/st",
-    "description": "Flera färger. 3 kr går till Glada Hudik | ICA | Jfr pris 99:00/st | Ord.pris 149:00 kr.",
-    "ord_pris": "149:00",
-    "jfr_pris": "99:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4a2bdd3edaa948f6b62cb5d8344b0b99&w=276&s=036ed0ae702e2129cbd88e16bc979abe"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Yoghurt",
-    "price": "45:-",
+    "name": "Majs-, Riskakor",
+    "price": "35:-",
     "unit": "2 för",
-    "description": "1000 g | Gäller Original och Mini. Gäller ej laktosfri | Yoggi | Jfr pris 22:50/kg | Ord.pris 30:90-32:90 kr.",
-    "ord_pris": "30:90-32:90",
-    "jfr_pris": "22:50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdb48f5526a71957ba588cca3f850b9f9&w=276&s=b357c1efae6b506cef081951844f2d0d"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Schampo, balsam",
-    "price": "55:-",
-    "unit": "2 för",
-    "description": "200-250 ml | Elvital | Jfr pris 110:00-137:50/liter | Ord.pris 43:90 kr.",
-    "ord_pris": "43:90",
-    "jfr_pris": "110:00-137:50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Ff4089f049893a20805cd31fd0b297ac8&w=276&s=2a70ab02e2b869c0203d38446b00ad5a"
+    "description": "120-125 g | Gäller ej tunna och ekologiska | Friggs | Jfr pris 140:00-145:83/kg | Ord.pris 24:90-26:90 kr.",
+    "ord_pris": "24:90-26:90",
+    "jfr_pris": "140:00-145:83",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4e143ad28ec3305230865d562798341a&w=276&s=24dfa05210b86509351881448ad911b4"
   },
   {
     "store": "ICA Supermarket",
@@ -91,13 +71,33 @@
   },
   {
     "store": "ICA Supermarket",
+    "name": "Färsk kycklingfilé",
+    "price": "119:-",
+    "unit": "/kg",
+    "description": "Ca 925 g | Naturell | Kronfågel | Ord.pris 179:00 kr.",
+    "ord_pris": "179:00",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbc6cdf46c7d9947e3582c7d8ac0c6b4b&w=568&s=55798203b8c36ccc5e38979c53827913"
+  },
+  {
+    "store": "ICA Supermarket",
     "name": "Fryst hamburgare",
     "price": "139:-",
     "unit": "2 för",
     "description": "720 g | 8-pack | ICA | Max 1 köp/hushåll | Jfr pris 96:53/kg | Ord.pris 90:90 kr.",
     "ord_pris": "90:90",
     "jfr_pris": "96:53",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F1e4abb26ebc3fd0d2becce1017e9dd68&w=576&s=8323020365015eecc5084f3ff1eb0dc3"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F1e4abb26ebc3fd0d2becce1017e9dd68&w=272&s=1bdab00deeca642eb26c8f33b6aa603b"
+  },
+  {
+    "store": "ICA Supermarket",
+    "name": "Flytande tvättmedel",
+    "price": "119:-",
+    "unit": "4 för",
+    "description": "880-920 ml | A+ | Max 1 köp/hushåll | Jfr pris 1:29-1:35/tvätt | Ord.pris 47:90-51:90 kr.",
+    "ord_pris": "47:90-51:90",
+    "jfr_pris": "1:29-1:35",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F705165b1e3dcd159a8b23b9a7b4fbc8a&w=272&s=c41f86d3b31a63b1d7661baf53c8fb43"
   },
   {
     "store": "ICA Supermarket",
@@ -141,83 +141,43 @@
   },
   {
     "store": "ICA Supermarket",
-    "name": "Färsk kycklingfilé",
-    "price": "119:-",
-    "unit": "/kg",
-    "description": "Ca 925 g | Naturell | Kronfågel | Ord.pris 179:00 kr.",
-    "ord_pris": "179:00",
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbc6cdf46c7d9947e3582c7d8ac0c6b4b&w=568&s=55798203b8c36ccc5e38979c53827913"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Flytande tvättmedel",
-    "price": "119:-",
-    "unit": "4 för",
-    "description": "880-920 ml | A+ | Max 1 köp/hushåll | Jfr pris 1:29-1:35/tvätt | Ord.pris 47:90-51:90 kr.",
-    "ord_pris": "47:90-51:90",
-    "jfr_pris": "1:29-1:35",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F705165b1e3dcd159a8b23b9a7b4fbc8a&w=272&s=c41f86d3b31a63b1d7661baf53c8fb43"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Levainbröd",
+    "name": "Röda kärnfria druvor i ask",
     "price": "30:-",
     "unit": "/st",
-    "description": "650 g | Gäller råg- och vetelevain | Pågen | Jfr pris 46:15/kg | Ord.pris 44:90 kr.",
-    "ord_pris": "44:90",
-    "jfr_pris": "46:15",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdf64e3e6b34ee3524573b8150f4ca20b&w=276&s=e1ea902cea9a6ca840eddbf4cddb80f5"
+    "description": "500 g | Klass 1 | ICA | Jfr pris 60:00/kg | Ord.pris 49:90 kr.",
+    "ord_pris": "49:90",
+    "jfr_pris": "60:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F13e970b11f58bed03a7aff22ca8e2655&w=276&s=1b2a2c4b201a8aec2084577895c76ebd"
   },
   {
     "store": "ICA Supermarket",
-    "name": "Majs-, Riskakor",
-    "price": "35:-",
-    "unit": "2 för",
-    "description": "120-125 g | Gäller ej tunna och ekologiska | Friggs | Jfr pris 140:00-145:83/kg | Ord.pris 24:90-26:90 kr.",
-    "ord_pris": "24:90-26:90",
-    "jfr_pris": "140:00-145:83",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4e143ad28ec3305230865d562798341a&w=276&s=24dfa05210b86509351881448ad911b4"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Falukorv",
-    "price": "69:-",
-    "unit": "2 för",
-    "description": "800 g | Scan | Max 1 köp/hushåll | Jfr pris 43:12/kg | Ord.pris 41:90 kr.",
-    "ord_pris": "41:90",
-    "jfr_pris": "43:12",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fc565c59956f8ab34e5e906b665f13e12&w=276&s=6dd974f4b33702d58286fa796e18a3a8"
-  },
-  {
-    "store": "ICA Supermarket",
-    "name": "Grevé®, Herrgård®, Präst®, Rike®, Ära®",
-    "price": "79:-",
+    "name": "Tulpaner 12-pack",
+    "price": "99:-",
     "unit": "/st",
-    "description": "670 g | 28-35%. Mildlagrad | Skånemejerier | Jfr pris 117:91/kg | Ord.pris 105:00-119:00 kr.",
-    "ord_pris": "105:00-119:00",
-    "jfr_pris": "117:91",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4c8a9a7088268c83673ee4d38ba15475&w=276&s=6651e73eb98b88d20c0ac2d10432a76a"
+    "description": "Flera färger. 3 kr går till Glada Hudik | ICA | Jfr pris 99:00/st | Ord.pris 149:00 kr.",
+    "ord_pris": "149:00",
+    "jfr_pris": "99:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4a2bdd3edaa948f6b62cb5d8344b0b99&w=276&s=036ed0ae702e2129cbd88e16bc979abe"
   },
   {
     "store": "ICA Supermarket",
-    "name": "Skinkstek",
-    "price": null,
-    "unit": "/kg",
-    "description": "Ca 1100 g | ICA | Max 2 köp/hushåll | Ord.pris 115:00 kr.",
-    "ord_pris": "115:00",
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F5e81e74988d197818f51f94cd35e8f3d&w=276&s=ee9200358420b929f56bb5e9d78344da"
+    "name": "Yoghurt",
+    "price": "45:-",
+    "unit": "2 för",
+    "description": "1000 g | Gäller Original och Mini. Gäller ej laktosfri | Yoggi | Jfr pris 22:50/kg | Ord.pris 30:90-32:90 kr.",
+    "ord_pris": "30:90-32:90",
+    "jfr_pris": "22:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdb48f5526a71957ba588cca3f850b9f9&w=276&s=b357c1efae6b506cef081951844f2d0d"
   },
   {
     "store": "ICA Supermarket",
-    "name": "Köttbullar",
-    "price": "69:-",
-    "unit": "/st",
-    "description": "1000 g | Kylda | Scan | Max 2 köp/hushåll | Jfr pris 69:00/kg | Ord.pris 89:90 kr.",
-    "ord_pris": "89:90",
-    "jfr_pris": "69:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F580b05d3c0e669fd8e209463159c42a8&w=276&s=2f2c9609846165a75058ea6b5cf20255"
+    "name": "Schampo, balsam",
+    "price": "55:-",
+    "unit": "2 för",
+    "description": "200-250 ml | Elvital | Jfr pris 110:00-137:50/liter | Ord.pris 43:90 kr.",
+    "ord_pris": "43:90",
+    "jfr_pris": "110:00-137:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Ff4089f049893a20805cd31fd0b297ac8&w=276&s=2a70ab02e2b869c0203d38446b00ad5a"
   },
   {
     "store": "ICA Supermarket",
@@ -268,6 +228,46 @@
     "ord_pris": "31:90-36:90",
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbf2e7746f1f22dc84c49733914afa703&w=276&s=1758f994da6eadd070709fa512057721"
+  },
+  {
+    "store": "ICA Supermarket",
+    "name": "Falukorv",
+    "price": "69:-",
+    "unit": "2 för",
+    "description": "800 g | Scan | Max 1 köp/hushåll | Jfr pris 43:12/kg | Ord.pris 41:90 kr.",
+    "ord_pris": "41:90",
+    "jfr_pris": "43:12",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fc565c59956f8ab34e5e906b665f13e12&w=276&s=6dd974f4b33702d58286fa796e18a3a8"
+  },
+  {
+    "store": "ICA Supermarket",
+    "name": "Grevé®, Herrgård®, Präst®, Rike®, Ära®",
+    "price": "79:-",
+    "unit": "/st",
+    "description": "670 g | 28-35%. Mildlagrad | Skånemejerier | Jfr pris 117:91/kg | Ord.pris 105:00-119:00 kr.",
+    "ord_pris": "105:00-119:00",
+    "jfr_pris": "117:91",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4c8a9a7088268c83673ee4d38ba15475&w=276&s=6651e73eb98b88d20c0ac2d10432a76a"
+  },
+  {
+    "store": "ICA Supermarket",
+    "name": "Skinkstek",
+    "price": null,
+    "unit": "/kg",
+    "description": "Ca 1100 g | ICA | Max 2 köp/hushåll | Ord.pris 115:00 kr.",
+    "ord_pris": "115:00",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F5e81e74988d197818f51f94cd35e8f3d&w=276&s=ee9200358420b929f56bb5e9d78344da"
+  },
+  {
+    "store": "ICA Supermarket",
+    "name": "Köttbullar",
+    "price": "69:-",
+    "unit": "/st",
+    "description": "1000 g | Kylda | Scan | Max 2 köp/hushåll | Jfr pris 69:00/kg | Ord.pris 89:90 kr.",
+    "ord_pris": "89:90",
+    "jfr_pris": "69:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F580b05d3c0e669fd8e209463159c42a8&w=276&s=2f2c9609846165a75058ea6b5cf20255"
   },
   {
     "store": "ICA Supermarket",
@@ -521,13 +521,53 @@
   },
   {
     "store": "ICA Nära",
+    "name": "Skärgårdskaka",
+    "price": "30:-",
+    "unit": "/st",
+    "description": "750 g | Pågen | Jfr pris 40:00/kg | Ord.pris 37:95 kr.",
+    "ord_pris": "37:95",
+    "jfr_pris": "40:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fa5d5a980715cfd17b918c5d0d8bf4c44&w=572&s=223ef2083b6ea6a9066ebbad684e4444"
+  },
+  {
+    "store": "ICA Nära",
+    "name": "Cookies",
+    "price": "25:-",
+    "unit": "/st",
+    "description": "132-184 g | Marabou | Jfr pris 135:87-189:39/kg | Ord.pris 35:95-41:95 kr. 30dgr.pris 35:95-41:95 kr.",
+    "ord_pris": "35:95-41:95",
+    "jfr_pris": "135:87-189:39",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F2df9bfed47224b15f8d661fe653be351&w=572&s=bbbda2e91172264e6ec37e7f165b1a2a"
+  },
+  {
+    "store": "ICA Nära",
+    "name": "Färsk kycklingfilé",
+    "price": "119:-",
+    "unit": "/kg",
+    "description": "Ca 925 g | Naturell | Kronfågel | Ord.pris 177:00 kr.",
+    "ord_pris": "177:00",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fbc6cdf46c7d9947e3582c7d8ac0c6b4b&w=568&s=2d0f5575561d7948d7ff271692340c34"
+  },
+  {
+    "store": "ICA Nära",
     "name": "Fryst hamburgare",
     "price": "139:-",
     "unit": "2 för",
     "description": "720 g | 8-pack | ICA | Max 1 köp/hushåll | Jfr pris 96:53/kg | Ord.pris 92:00 kr.",
     "ord_pris": "92:00",
     "jfr_pris": "96:53",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F1e4abb26ebc3fd0d2becce1017e9dd68&w=576&s=c5c44801e7b24cd9a6975e2cd176c6bc"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F1e4abb26ebc3fd0d2becce1017e9dd68&w=272&s=bb66f7932b3cb957260581bee1d23f35"
+  },
+  {
+    "store": "ICA Nära",
+    "name": "Flytande tvättmedel",
+    "price": "119:-",
+    "unit": "4 för",
+    "description": "880-920 ml | A+ | Max 1 köp/hushåll | Jfr pris 1:29-1:35/tvätt | Ord.pris 51:95-53:95 kr.",
+    "ord_pris": "51:95-53:95",
+    "jfr_pris": "1:29-1:35",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F705165b1e3dcd159a8b23b9a7b4fbc8a&w=272&s=5ab90ddd164329428f4bc98ff0b267d5"
   },
   {
     "store": "ICA Nära",
@@ -538,16 +578,6 @@
     "ord_pris": "46:95",
     "jfr_pris": "84:76-98:89",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fc412ff45e9f72f3c87b0e20bff3838ff&w=276&s=020c7f2d295bd74b71a5042297c1d0eb"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Pommes Frites, Strips",
-    "price": "30:-",
-    "unit": "2 för",
-    "description": "1 kg | Fryst | ICA | Max 1 köp/hushåll | Jfr pris 15:00/kg | Ord.pris 28:95 kr.",
-    "ord_pris": "28:95",
-    "jfr_pris": "15:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F0459fc8294dee52006c0aa4c488de8bd&w=276&s=ed1161dc11b9a95215b7c71eb98b8cba"
   },
   {
     "store": "ICA Nära",
@@ -571,53 +601,13 @@
   },
   {
     "store": "ICA Nära",
-    "name": "Färsk kycklingfilé",
-    "price": "119:-",
-    "unit": "/kg",
-    "description": "Ca 925 g | Naturell | Kronfågel | Ord.pris 177:00 kr.",
-    "ord_pris": "177:00",
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fbc6cdf46c7d9947e3582c7d8ac0c6b4b&w=568&s=2d0f5575561d7948d7ff271692340c34"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Flytande tvättmedel",
-    "price": "119:-",
-    "unit": "4 för",
-    "description": "880-920 ml | A+ | Max 1 köp/hushåll | Jfr pris 1:29-1:35/tvätt | Ord.pris 51:95-53:95 kr.",
-    "ord_pris": "51:95-53:95",
-    "jfr_pris": "1:29-1:35",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F705165b1e3dcd159a8b23b9a7b4fbc8a&w=272&s=5ab90ddd164329428f4bc98ff0b267d5"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Skärgårdskaka",
-    "price": "30:-",
+    "name": "Smör",
+    "price": "55:-",
     "unit": "/st",
-    "description": "750 g | Pågen | Jfr pris 40:00/kg | Ord.pris 37:95 kr.",
-    "ord_pris": "37:95",
-    "jfr_pris": "40:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fa5d5a980715cfd17b918c5d0d8bf4c44&w=572&s=223ef2083b6ea6a9066ebbad684e4444"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Cookies",
-    "price": "25:-",
-    "unit": "/st",
-    "description": "132-184 g | Marabou | Jfr pris 135:87-189:39/kg | Ord.pris 35:95-41:95 kr. 30dgr.pris 35:95-41:95 kr.",
-    "ord_pris": "35:95-41:95",
-    "jfr_pris": "135:87-189:39",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F2df9bfed47224b15f8d661fe653be351&w=572&s=bbbda2e91172264e6ec37e7f165b1a2a"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Mogen avokado 3-pack",
-    "price": "25:-",
-    "unit": "/st",
-    "description": "330 g | Klass 1 | ICA | Max 2 köp/hushåll | Jfr pris 75:76/kg | Ord.pris 44:95 kr.",
-    "ord_pris": "44:95",
-    "jfr_pris": "75:76",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F73a77ff93e399993cbd895c884656b09&w=576&s=e2b88bfd00674eaa0cb8ac5d0cb792d8"
+    "description": "500 g | Gäller ej laktosfritt | Valio | Jfr pris 110:00/kg | Ord.pris 78:00 kr.",
+    "ord_pris": "78:00",
+    "jfr_pris": "110:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F47965113bfe5e5a833988c7c05a6db91&w=576&s=40d08a8d7c375edcd3631babd783fed9"
   },
   {
     "store": "ICA Nära",
@@ -628,6 +618,26 @@
     "ord_pris": "38:95",
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F61b7036d34d450798eb8eeb2b84f7e23&w=276&s=401591d59b038b214b28ccd74b902ca3"
+  },
+  {
+    "store": "ICA Nära",
+    "name": "LED Lampor",
+    "price": "60:-",
+    "unit": "3 för",
+    "description": "Erbjudandet gäller: LED SMD E27 806lm/E27 470lm/E27 250lm/E14 250lm/E14 140lm/E14 250lm | ICA | Jfr pris 20:00/st | Ord.pris 23:95-25:95 kr.",
+    "ord_pris": "23:95-25:95",
+    "jfr_pris": "20:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fecaf7c700af532daf20d29e61e08385d&w=276&s=40a2e59af77ddf276dfbc81b61d16463"
+  },
+  {
+    "store": "ICA Nära",
+    "name": "Proteinbar",
+    "price": "55:-",
+    "unit": "3 för",
+    "description": "55 g | Swebar | Jfr pris 333:33/kg | Ord.pris 27:95-28:95 kr.",
+    "ord_pris": "27:95-28:95",
+    "jfr_pris": "333:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F2be2ef156e6a7da71ef3394549aa67e5&w=276&s=f9dedc1501a011db3e222d36ba47f005"
   },
   {
     "store": "ICA Nära",
@@ -661,33 +671,33 @@
   },
   {
     "store": "ICA Nära",
-    "name": "Smör",
-    "price": "55:-",
+    "name": "Päron i korg",
+    "price": "15:-",
     "unit": "/st",
-    "description": "500 g | Gäller ej laktosfritt | Valio | Jfr pris 110:00/kg | Ord.pris 78:00 kr.",
-    "ord_pris": "78:00",
-    "jfr_pris": "110:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F47965113bfe5e5a833988c7c05a6db91&w=576&s=40d08a8d7c375edcd3631babd783fed9"
+    "description": "1 kg | Klass 2 | ICA | Jfr pris 15:00/kg | Ord.pris 19:95 kr.",
+    "ord_pris": "19:95",
+    "jfr_pris": "15:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F33f6345dfc1cee3056d7e77038420d11&w=276&s=7f23e088d92ae8c90c8d46d7d8773d7c"
   },
   {
     "store": "ICA Nära",
-    "name": "LED Lampor",
-    "price": "60:-",
-    "unit": "3 för",
-    "description": "Erbjudandet gäller: LED SMD E27 806lm/E27 470lm/E27 250lm/E14 250lm/E14 140lm/E14 250lm | ICA | Jfr pris 20:00/st | Ord.pris 23:95-25:95 kr.",
-    "ord_pris": "23:95-25:95",
-    "jfr_pris": "20:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fecaf7c700af532daf20d29e61e08385d&w=276&s=40a2e59af77ddf276dfbc81b61d16463"
+    "name": "Blåbär i ask",
+    "price": "20:-",
+    "unit": "/st",
+    "description": "125 g | Klass 1 | ICA | Jfr pris 160:00/kg | Ord.pris 33:95 kr.",
+    "ord_pris": "33:95",
+    "jfr_pris": "160:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fc912bb556460239d6e9a37f7e250f56e&w=276&s=f7044ad6c5eebf0c35d0c31f46ff4970"
   },
   {
     "store": "ICA Nära",
-    "name": "Proteinbar",
-    "price": "55:-",
-    "unit": "3 för",
-    "description": "55 g | Swebar | Jfr pris 333:33/kg | Ord.pris 27:95-28:95 kr.",
-    "ord_pris": "27:95-28:95",
-    "jfr_pris": "333:33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F2be2ef156e6a7da71ef3394549aa67e5&w=276&s=f9dedc1501a011db3e222d36ba47f005"
+    "name": "Socker- och salladsärtor i påse",
+    "price": "20:-",
+    "unit": "/st",
+    "description": "150 g | Klass 1 | ICA | Jfr pris 133:33/kg | Ord.pris 29:95-34:95 kr.",
+    "ord_pris": "29:95-34:95",
+    "jfr_pris": "133:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Ff7099ec1b281da8081851125145ed695&w=276&s=51f1ce32074963aed6e78419103a3bae"
   },
   {
     "store": "ICA Nära",
@@ -708,66 +718,6 @@
     "ord_pris": "29:95-35:95",
     "jfr_pris": "125:00-222:22",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F30ec19492c99259609a9fbcc43826838&w=276&s=5f73400d03ad7f1f98e667e018481637"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Pizzakit",
-    "price": "30:-",
-    "unit": "2 för",
-    "description": "600 g | ICA | Max 1 köp/hushåll | Jfr pris 25:00/kg | Ord.pris 29:95 kr.",
-    "ord_pris": "29:95",
-    "jfr_pris": "25:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F3ec2166be2b389574b47f7394003163f&w=276&s=99fd4ce89412721d2b775e1568bb72ad"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Kebab",
-    "price": "30:-",
-    "unit": "/st",
-    "description": "275 g | Gäller ej Dönerkebab | Schysst käk | Max 2 köp/hushåll | Jfr pris 109:09/kg | Ord.pris 55:00-58:95 kr.",
-    "ord_pris": "55:00-58:95",
-    "jfr_pris": "109:09",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fdf093ead3418701315d9f412ab1fbcd5&w=276&s=af2ef2c760b394c195ac248f40cc9f7b"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Päron i korg",
-    "price": "15:-",
-    "unit": "/st",
-    "description": "1 kg | Klass 2 | ICA | Jfr pris 15:00/kg | Ord.pris 19:95 kr.",
-    "ord_pris": "19:95",
-    "jfr_pris": "15:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F33f6345dfc1cee3056d7e77038420d11&w=572&s=0e3c29edc6d23834b96a716739440ae6"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Blåbär i ask",
-    "price": "20:-",
-    "unit": "/st",
-    "description": "125 g | Klass 1 | ICA | Jfr pris 160:00/kg | Ord.pris 33:95 kr.",
-    "ord_pris": "33:95",
-    "jfr_pris": "160:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Fc912bb556460239d6e9a37f7e250f56e&w=276&s=f7044ad6c5eebf0c35d0c31f46ff4970"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Socker- och salladsärtor i påse",
-    "price": "20:-",
-    "unit": "/st",
-    "description": "150 g | Klass 1 | ICA | Jfr pris 133:33/kg | Ord.pris 34:95-36:95 kr.",
-    "ord_pris": "34:95-36:95",
-    "jfr_pris": "133:33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2Ff7099ec1b281da8081851125145ed695&w=276&s=51f1ce32074963aed6e78419103a3bae"
-  },
-  {
-    "store": "ICA Nära",
-    "name": "Riven ost",
-    "price": "30:-",
-    "unit": "2 för",
-    "description": "150 g | Gratäng, pizza, taco, matlagning, cheddar/mozzarella | ICA | Max 1 köp/hushåll | Jfr pris 100:00/kg | Ord.pris 26:95 kr.",
-    "ord_pris": "26:95",
-    "jfr_pris": "100:00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F079775cff61879e4ac82477fd244328e&w=276&s=4a1061e845b9b8d51b47792aa0923a9f"
   },
   {
     "store": "ICA Nära",
@@ -881,16 +831,6 @@
   },
   {
     "store": "ICA Nära",
-    "name": "Kexchoklad",
-    "price": "65:-",
-    "unit": "10 för",
-    "description": "60 g | Cloetta | Max 1 köp/hushåll | Jfr pris 108:33/kg | Ord.pris 14:95 kr.",
-    "ord_pris": "14:95",
-    "jfr_pris": "108:33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F240ce2fe60be946369e66efed5aafbde&w=276&s=27d0ce68ffc5bbf7a4e8f9c502ef99b0"
-  },
-  {
-    "store": "ICA Nära",
     "name": "Kattmat multipack",
     "price": "49:-",
     "unit": "/st",
@@ -917,7 +857,7 @@
     "description": "6-pack | 6x33 cl. | Coca-Cola, Fanta | Jfr pris 21:46/liter + pant | Ord.pris 57:00 kr.",
     "ord_pris": "57:00",
     "jfr_pris": "21:46",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F15f4c72da8cfcf3b609d3da729d14513&w=288&s=6eee108e2f57e9b4cbe0d8a6719c06ba"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F20d4lA%2F15f4c72da8cfcf3b609d3da729d14513&w=276&s=dbc6d614a45f61eb473d6156677eaaaa"
   },
   {
     "store": "ICA Nära",
@@ -961,13 +901,13 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "CRUNCHITASALLAT I PÅSE",
-    "price": "15:-",
+    "name": "BLÅBÄR I ASK",
+    "price": "20:-",
     "unit": null,
-    "description": "200 g • 75 kr/kg",
+    "description": "125 g • 160 kr/kg",
     "ord_pris": null,
-    "jfr_pris": "75",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-3.webp&w=300&x1r=0.6809&x2r=0.9618&y1r=0.0295&y2r=0.346&s=c621d7697d5c7883dbff81738a512852"
+    "jfr_pris": "160",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-3.webp&w=300&x1r=0.4402&x2r=0.7092&y1r=0.0314&y2r=0.287&s=8b6a26b1c5d5d2ed018e1b427f7a3600"
   },
   {
     "store": "ICA Maxi",
@@ -981,13 +921,13 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "BLÅBÄR I ASK",
-    "price": "20:-",
+    "name": "CRUNCHITASALLAT I PÅSE",
+    "price": "15:-",
     "unit": null,
-    "description": "125 g • 160 kr/kg",
+    "description": "200 g • 75 kr/kg",
     "ord_pris": null,
-    "jfr_pris": "160",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-3.webp&w=300&x1r=0.4402&x2r=0.7092&y1r=0.0314&y2r=0.287&s=8b6a26b1c5d5d2ed018e1b427f7a3600"
+    "jfr_pris": "75",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-3.webp&w=300&x1r=0.6809&x2r=0.9618&y1r=0.0295&y2r=0.346&s=c621d7697d5c7883dbff81738a512852"
   },
   {
     "store": "ICA Maxi",
@@ -1047,7 +987,7 @@
     "description": "500 g • 50 kr/kg",
     "ord_pris": null,
     "jfr_pris": "50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-1.webp&w=300&x1r=0.6316&x2r=0.9614&y1r=0.0519&y2r=0.2382&s=f4c0c5b510a0f04cf4e36f15d377ed4b"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-3.webp&w=300&x1r=0.0417&x2r=0.3057&y1r=0.0372&y2r=0.4361&s=29047fc3c96969900d1fc5d91ed108af"
   },
   {
     "store": "ICA Maxi",
@@ -1062,7 +1002,7 @@
   {
     "store": "ICA Maxi",
     "name": "FÄRSK KYCKLINGFILÉ",
-    "price": "Medlemspris",
+    "price": "119:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1081,16 +1021,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "KRYDDADE FLÄSKMEDALJONGER",
-    "price": "39.90:-",
-    "unit": null,
-    "description": "300 g • 133 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "133",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.3749&x2r=0.9549&y1r=0.0206&y2r=0.2544&s=8657e75aaf72871d8db9eede144485ef"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "PULLED PORK",
     "price": "39.90:-",
     "unit": null,
@@ -1101,8 +1031,18 @@
   },
   {
     "store": "ICA Maxi",
+    "name": "KRYDDADE FLÄSKMEDALJONGER",
+    "price": "39.90:-",
+    "unit": null,
+    "description": "300 g • 133 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "133",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.3749&x2r=0.9549&y1r=0.0206&y2r=0.2544&s=8657e75aaf72871d8db9eede144485ef"
+  },
+  {
+    "store": "ICA Maxi",
     "name": "FALUKORV",
-    "price": "Medlemspris",
+    "price": "69:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1118,6 +1058,26 @@
     "ord_pris": null,
     "jfr_pris": "113,33",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.0561&x2r=0.3809&y1r=0.2311&y2r=0.4646&s=aad24c6a68779a8e285fa01f785c6b51"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "BABY BACK RIBS",
+    "price": "59.90:-",
+    "unit": null,
+    "description": "475 g • 126,11 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "126,11",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.0511&x2r=0.3892&y1r=0.0286&y2r=0.2361&s=cb6cadd543a0a33b307fd4537fdd073a"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "GRILLKORV",
+    "price": "57.90:-",
+    "unit": null,
+    "description": "900-960 g • 64,33 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "64,33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.2761&x2r=0.5002&y1r=0.4588&y2r=0.6937&s=9b4a71009b412d1c97eab11235b89537"
   },
   {
     "store": "ICA Maxi",
@@ -1141,26 +1101,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "FÄRSK PANERAD SCHNITZEL",
-    "price": "44.90:-",
-    "unit": null,
-    "description": "300 g • 149,67 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "149,67",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.5051&x2r=0.7439&y1r=0.4657&y2r=0.697&s=72377408b9de95137c7f2286fb83b7f8"
-  },
-  {
-    "store": "ICA Maxi",
-    "name": "GRILLKORV",
-    "price": "57.90:-",
-    "unit": null,
-    "description": "900-960 g • 64,33 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "64,33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-2.webp&w=300&x1r=0.2761&x2r=0.5002&y1r=0.4588&y2r=0.6937&s=9b4a71009b412d1c97eab11235b89537"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "ÄGG, FRIGÅENDE",
     "price": "25:-",
     "unit": null,
@@ -1171,16 +1111,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "CHEDDAR",
-    "price": "139.90:-",
-    "unit": null,
-    "description": "1 kg • 139,90 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "139,90",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-5.webp&w=300&x1r=0.372&x2r=0.6747&y1r=0.2677&y2r=0.4953&s=deb1b95541ae89bebddb3e11e42185e6"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "LAKTOSFRI MJÖLK",
     "price": "42:-",
     "unit": null,
@@ -1188,6 +1118,16 @@
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-4.webp&w=300&x1r=0.7194&x2r=0.9506&y1r=0.2095&y2r=0.4864&s=7b433e42b073742464aa0ca6f4409adb"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "CHEDDAR",
+    "price": "139.90:-",
+    "unit": null,
+    "description": "1 kg • 139,90 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "139,90",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-5.webp&w=300&x1r=0.372&x2r=0.6747&y1r=0.2677&y2r=0.4953&s=deb1b95541ae89bebddb3e11e42185e6"
   },
   {
     "store": "ICA Maxi",
@@ -1221,16 +1161,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "GRILLOUMI, HALLOUMI",
-    "price": "59:-",
-    "unit": null,
-    "description": "2x200-240 g • 147,50 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "147,50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-5.webp&w=300&x1r=0.0641&x2r=0.3705&y1r=0.2656&y2r=0.4985&s=17662810b1818b2abbaca0a8d8b66c7a"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "FILMJÖLK",
     "price": "19.90:-",
     "unit": null,
@@ -1238,6 +1168,16 @@
     "ord_pris": null,
     "jfr_pris": "19,90",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-4.webp&w=300&x1r=0.4439&x2r=0.6406&y1r=0.7147&y2r=0.9555&s=a70504afa2c4e372dbfa58d6f83f378c"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "GRILLOUMI, HALLOUMI",
+    "price": "59:-",
+    "unit": null,
+    "description": "2x200-240 g • 147,50 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "147,50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-5.webp&w=300&x1r=0.0641&x2r=0.3705&y1r=0.2656&y2r=0.4985&s=17662810b1818b2abbaca0a8d8b66c7a"
   },
   {
     "store": "ICA Maxi",
@@ -1301,16 +1241,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "FRYSTA THAIBOXAR",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.3502&x2r=0.5576&y1r=0.0264&y2r=0.3369&s=a3d0beb37292f01b89e360c793543f83"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "POTATISGRATÄNG",
     "price": "57.90:-",
     "unit": null,
@@ -1341,13 +1271,13 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "FRYST PIZZA RISTORANTE",
+    "name": "FRYSTA THAIBOXAR",
     "price": "89:-",
     "unit": null,
-    "description": "3x320-360 g • 92,71 kr/kg",
+    "description": null,
     "ord_pris": null,
-    "jfr_pris": "92,71",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.4898&x2r=0.7429&y1r=0.649&y2r=0.9555&s=1f12de5786a0a7152cdde345a5ff5215"
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.3502&x2r=0.5576&y1r=0.0264&y2r=0.3369&s=a3d0beb37292f01b89e360c793543f83"
   },
   {
     "store": "ICA Maxi",
@@ -1371,8 +1301,18 @@
   },
   {
     "store": "ICA Maxi",
+    "name": "FRYST PIZZA RISTORANTE",
+    "price": "89:-",
+    "unit": null,
+    "description": "3x320-360 g • 92,71 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "92,71",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.4898&x2r=0.7429&y1r=0.649&y2r=0.9555&s=1f12de5786a0a7152cdde345a5ff5215"
+  },
+  {
+    "store": "ICA Maxi",
     "name": "FRYST HAMBURGARE",
-    "price": "Medlemspris",
+    "price": "139:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1401,16 +1341,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "KYLD SÅS, DRESSING",
-    "price": "35:-",
-    "unit": null,
-    "description": "2x170-255 ml • 102,94 kr/l",
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.5357&x2r=0.7534&y1r=0.0329&y2r=0.3326&s=15af357edd4972c1155ebf61144f6163"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "TE",
     "price": "39:-",
     "unit": null,
@@ -1428,6 +1358,16 @@
     "ord_pris": null,
     "jfr_pris": "21,33",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.7179&x2r=0.9597&y1r=0.6546&y2r=0.9649&s=b3cd687cf40446ee98478528ecb161ad"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "KYLD SÅS, DRESSING",
+    "price": "35:-",
+    "unit": null,
+    "description": "2x170-255 ml • 102,94 kr/l",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-6.webp&w=300&x1r=0.5357&x2r=0.7534&y1r=0.0329&y2r=0.3326&s=15af357edd4972c1155ebf61144f6163"
   },
   {
     "store": "ICA Maxi",
@@ -1462,7 +1402,7 @@
   {
     "store": "ICA Maxi",
     "name": "TÄNDKUBER",
-    "price": "Medlemspris",
+    "price": "69:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1572,7 +1512,7 @@
   {
     "store": "ICA Maxi",
     "name": "TOALETTPAPPER, HUSHÅLLSPAPPER CLASSIC",
-    "price": "Medlemspris",
+    "price": "95:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1582,7 +1522,7 @@
   {
     "store": "ICA Maxi",
     "name": "FLYTANDE TVÄTTMEDEL",
-    "price": "Medlemspris",
+    "price": "119:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1622,7 +1562,7 @@
   {
     "store": "ICA Maxi",
     "name": "ENGÅNGSHANDSKE",
-    "price": "Medlemspris",
+    "price": "75:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1642,7 +1582,7 @@
   {
     "store": "ICA Maxi",
     "name": "WC-SET",
-    "price": "Medlemspris",
+    "price": "40:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1652,12 +1592,22 @@
   {
     "store": "ICA Maxi",
     "name": "MATLÅDA",
-    "price": "Medlemspris",
+    "price": "50:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-11.webp&w=300&x1r=0.5595&x2r=0.9573&y1r=0.7555&y2r=0.9606&s=96d76f24546f183fa5346819ecb17d25"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "VED 30 L",
+    "price": "80:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-15.webp&w=300&x1r=0.3724&x2r=0.7049&y1r=0.2291&y2r=0.4062&s=b72137b22f84fd44ad28efd251fe5064"
   },
   {
     "store": "ICA Maxi",
@@ -1702,22 +1652,12 @@
   {
     "store": "ICA Maxi",
     "name": "DOFTLJUS",
-    "price": "Medlemspris",
+    "price": "50:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-1.webp&w=300&x1r=0.039&x2r=0.261&y1r=0.6995&y2r=0.9634&s=291f80f16cf4d33f0270f8c91cdc1b59"
-  },
-  {
-    "store": "ICA Maxi",
-    "name": "VED 30 L",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-15.webp&w=300&x1r=0.3724&x2r=0.7049&y1r=0.2291&y2r=0.4062&s=b72137b22f84fd44ad28efd251fe5064"
   },
   {
     "store": "ICA Maxi",
@@ -1762,12 +1702,22 @@
   {
     "store": "ICA Maxi",
     "name": "BATTERIER",
-    "price": "Medlemspris",
+    "price": "75:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-15.webp&w=300&x1r=0.7143&x2r=0.9596&y1r=0.3979&y2r=0.6653&s=d2c5df37e9fc6937684f28c24fc292ef"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "KNAPPCELLSBATTERI",
+    "price": "50:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-15.webp&w=300&x1r=0.4905&x2r=0.7152&y1r=0.4052&y2r=0.6703&s=485a344b1a0c7feffc9ecad74baa2d3a"
   },
   {
     "store": "ICA Maxi",
@@ -1781,18 +1731,8 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "KNAPPCELLSBATTERI",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-15.webp&w=300&x1r=0.4905&x2r=0.7152&y1r=0.4052&y2r=0.6703&s=485a344b1a0c7feffc9ecad74baa2d3a"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "LADDKABEL USB-C-USB-C",
-    "price": "Medlemspris",
+    "price": "75:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1802,7 +1742,7 @@
   {
     "store": "ICA Maxi",
     "name": "VÄGGLADDARE USB-A",
-    "price": "Medlemspris",
+    "price": "75:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1812,7 +1752,7 @@
   {
     "store": "ICA Maxi",
     "name": "VÄGGLADDARE USB-C",
-    "price": "Medlemspris",
+    "price": "99:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1822,7 +1762,7 @@
   {
     "store": "ICA Maxi",
     "name": "LADDKABEL LIGHTNING",
-    "price": "Medlemspris",
+    "price": "129:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -1871,6 +1811,16 @@
   },
   {
     "store": "ICA Maxi",
+    "name": "TOFFLOR VUXEN",
+    "price": "149:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-14.webp&w=300&x1r=0.7276&x2r=0.955&y1r=0.279&y2r=0.4853&s=51b7fd56e51583cc3a72cd1630c6c232"
+  },
+  {
+    "store": "ICA Maxi",
     "name": "JEANS",
     "price": "249:-",
     "unit": null,
@@ -1911,16 +1861,6 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "TOFFLOR VUXEN",
-    "price": "149:-",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-14.webp&w=300&x1r=0.7276&x2r=0.955&y1r=0.279&y2r=0.4853&s=51b7fd56e51583cc3a72cd1630c6c232"
-  },
-  {
-    "store": "ICA Maxi",
     "name": "PILÉJACKA",
     "price": "179:-",
     "unit": null,
@@ -1951,6 +1891,26 @@
   },
   {
     "store": "ICA Maxi",
+    "name": "FLYTANDE TVÅL REFILL",
+    "price": "39:-",
+    "unit": null,
+    "description": "2x500 ml • 39 kr/l",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-7.webp&w=300&x1r=0.2707&x2r=0.5303&y1r=0.6465&y2r=0.9619&s=9c5e16fc5a0626cb19840f5b3922b08a"
+  },
+  {
+    "store": "ICA Maxi",
+    "name": "ONEBLADE",
+    "price": "229:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-12.webp&w=300&x1r=0.0407&x2r=0.2995&y1r=0.3379&y2r=0.7362&s=5f0a1705849d491af0f2ab7638fdccc2"
+  },
+  {
+    "store": "ICA Maxi",
     "name": "TANDKRÄM, TANDBORSTE",
     "price": "28:-",
     "unit": null,
@@ -1971,6 +1931,16 @@
   },
   {
     "store": "ICA Maxi",
+    "name": "ONEBLADE RAKBLAD 3-PACK",
+    "price": "349:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-12.webp&w=300&x1r=0.304&x2r=0.529&y1r=0.3678&y2r=0.6558&s=37d81a3dba0de00aa7ad8b119a23a89b"
+  },
+  {
+    "store": "ICA Maxi",
     "name": "DEO SPRAY",
     "price": "59:-",
     "unit": null,
@@ -1981,23 +1951,13 @@
   },
   {
     "store": "ICA Maxi",
-    "name": "FLYTANDE TVÅL REFILL",
-    "price": "39:-",
+    "name": "DUSCHCREME",
+    "price": "55:-",
     "unit": null,
-    "description": "2x500 ml • 39 kr/l",
+    "description": "2x450 ml • 61,11 kr/l",
     "ord_pris": null,
     "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-7.webp&w=300&x1r=0.2707&x2r=0.5303&y1r=0.6465&y2r=0.9619&s=9c5e16fc5a0626cb19840f5b3922b08a"
-  },
-  {
-    "store": "ICA Maxi",
-    "name": "ONEBLADE RAKBLAD 3-PACK",
-    "price": "349:-",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-12.webp&w=300&x1r=0.304&x2r=0.529&y1r=0.3678&y2r=0.6558&s=37d81a3dba0de00aa7ad8b119a23a89b"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-7.webp&w=300&x1r=0.0463&x2r=0.2714&y1r=0.6468&y2r=0.9553&s=6000cf4068a48b26266e1708f5e53e39"
   },
   {
     "store": "ICA Maxi",
@@ -2012,32 +1972,12 @@
   {
     "store": "ICA Maxi",
     "name": "Apolosophy Hair",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-9.webp&w=300&x1r=0.66&x2r=0.9586&y1r=0.0292&y2r=0.1887&s=e444ed49d8409fdd2d7ba759a80be2ca"
-  },
-  {
-    "store": "ICA Maxi",
-    "name": "DUSCHCREME",
-    "price": "55:-",
-    "unit": null,
-    "description": "2x450 ml • 61,11 kr/l",
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-7.webp&w=300&x1r=0.0463&x2r=0.2714&y1r=0.6468&y2r=0.9553&s=6000cf4068a48b26266e1708f5e53e39"
-  },
-  {
-    "store": "ICA Maxi",
-    "name": "Fuktfavoriter för dig",
-    "price": "71:-",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FhPrjwBsB%2Fp-9.webp&w=300&x1r=0.0421&x2r=0.6471&y1r=0.622&y2r=0.8207&s=c084cf92effa8682fbfb32e0f42de916"
   },
   {
     "store": "ICA Maxi",
@@ -2071,16 +2011,6 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Apelsiner i nät",
-    "price": "15:-",
-    "unit": null,
-    "description": "1 kg • 15 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "15",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-1.webp&w=300&x1r=0.013&x2r=0.3214&y1r=0.4689&y2r=0.6866&s=98f0d0d360dcf96e41fc4279197c5150"
-  },
-  {
-    "store": "ICA Kvantum",
     "name": "Jordgubbar i ask",
     "price": "30:-",
     "unit": null,
@@ -2088,6 +2018,16 @@
     "ord_pris": null,
     "jfr_pris": "120",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.058&x2r=0.3141&y1r=0.1689&y2r=0.449&s=87464b3d21694859b50325398b3414f2"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Apelsiner i nät",
+    "price": "15:-",
+    "unit": null,
+    "description": "1 kg • 15 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "15",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.4936&x2r=0.7792&y1r=0.1767&y2r=0.4504&s=2d285169d373cb1b7a83950d23403244"
   },
   {
     "store": "ICA Kvantum",
@@ -2101,26 +2041,6 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Päron Conference",
-    "price": "20:-",
-    "unit": null,
-    "description": "1 kg • 20 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "20",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.7479&x2r=0.972&y1r=0.2345&y2r=0.4476&s=f4d2cc3688fc369d9764e085a1babf18"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Palsternackor i påse",
-    "price": "10:-",
-    "unit": null,
-    "description": "500 g • 20 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "20",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.0528&x2r=0.2877&y1r=0.4503&y2r=0.7152&s=52b3b1394dd2a21fe965ee4bd9941157"
-  },
-  {
-    "store": "ICA Kvantum",
     "name": "Plommontomater i ask",
     "price": "20:-",
     "unit": null,
@@ -2131,6 +2051,16 @@
   },
   {
     "store": "ICA Kvantum",
+    "name": "Päron Conference",
+    "price": "20:-",
+    "unit": null,
+    "description": "1 kg • 20 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "20",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.7479&x2r=0.972&y1r=0.2345&y2r=0.4476&s=f4d2cc3688fc369d9764e085a1babf18"
+  },
+  {
+    "store": "ICA Kvantum",
     "name": "Stor grön kiwi",
     "price": "20:-",
     "unit": null,
@@ -2138,6 +2068,16 @@
     "ord_pris": null,
     "jfr_pris": "53,33",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.6278&x2r=0.9681&y1r=0.0442&y2r=0.2452&s=c18d4cff88b7c51dc2b2cd5e5d51d623"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Palsternackor i påse",
+    "price": "10:-",
+    "unit": null,
+    "description": "500 g • 20 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "20",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-8.webp&w=300&x1r=0.0528&x2r=0.2877&y1r=0.4503&y2r=0.7152&s=52b3b1394dd2a21fe965ee4bd9941157"
   },
   {
     "store": "ICA Kvantum",
@@ -2202,7 +2142,7 @@
   {
     "store": "ICA Kvantum",
     "name": "Kaviar",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -2222,12 +2162,12 @@
   {
     "store": "ICA Kvantum",
     "name": "Färsk kycklingfilé",
-    "price": "Medlemspris",
+    "price": "119:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-4.webp&w=300&x1r=0.6729&x2r=0.9734&y1r=0.415&y2r=0.5758&s=16efd7cbc4f2d491a6b7761f378b7c31"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.6763&x2r=0.9649&y1r=0.2616&y2r=0.5194&s=fb2806d04d5587f90157a0224441b86a"
   },
   {
     "store": "ICA Kvantum",
@@ -2241,6 +2181,16 @@
   },
   {
     "store": "ICA Kvantum",
+    "name": "Kebab",
+    "price": "130:-",
+    "unit": null,
+    "description": "4x275 g • 118,18 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "118,18",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-2.webp&w=300&x1r=0.352&x2r=0.97&y1r=0.0518&y2r=0.3296&s=9f5b11de4ecc81e10964bbb893ce6cc5"
+  },
+  {
+    "store": "ICA Kvantum",
     "name": "Nötytterlår",
     "price": "149:-",
     "unit": null,
@@ -2248,16 +2198,6 @@
     "ord_pris": null,
     "jfr_pris": "149",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FwClCGEoL%2Fp-5.webp&w=300&x1r=0.4721&x2r=0.9501&y1r=0.0529&y2r=0.2675&s=694af3ddfdeb0d373c4cd32436bfff15"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Falukorv",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.0596&x2r=0.3914&y1r=0.2274&y2r=0.5121&s=8c48e6e21ce0854fe9dc06b812b5c253"
   },
   {
     "store": "ICA Kvantum",
@@ -2321,16 +2261,6 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Präst, Herrgård, Grevé, Morfars",
-    "price": "139:-",
-    "unit": null,
-    "description": "1 kg • 139 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "139",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.4921&x2r=0.7189&y1r=0.0543&y2r=0.2859&s=7f969f577fc9476b6beee745b5452623"
-  },
-  {
-    "store": "ICA Kvantum",
     "name": "Färskost",
     "price": "20:-",
     "unit": null,
@@ -2338,6 +2268,16 @@
     "ord_pris": null,
     "jfr_pris": "137,93",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.4417&x2r=0.7251&y1r=0.7272&y2r=0.9409&s=f38c42a37409c36495f83c4cb84278f8"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Präst, Herrgård, Grevé, Morfars",
+    "price": "139:-",
+    "unit": null,
+    "description": "1 kg • 139 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "139",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.4921&x2r=0.7189&y1r=0.0543&y2r=0.2859&s=7f969f577fc9476b6beee745b5452623"
   },
   {
     "store": "ICA Kvantum",
@@ -2402,7 +2342,7 @@
   {
     "store": "ICA Kvantum",
     "name": "Smörgåsmat",
-    "price": "Medlemspris",
+    "price": "40:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -2441,16 +2381,6 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Frysta pastarätter",
-    "price": "120:-",
-    "unit": null,
-    "description": "2x1000-1100 g • 60 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "60",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.4653&x2r=0.7117&y1r=0.4767&y2r=0.7303&s=c9710c191c1e58e098f932e2fed739ef"
-  },
-  {
-    "store": "ICA Kvantum",
     "name": "Gräddglass",
     "price": "70:-",
     "unit": null,
@@ -2458,6 +2388,16 @@
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.2662&x2r=0.492&y1r=0.704&y2r=0.9433&s=bb29ff0b1062c6f0d570705b93dc01aa"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Frysta pastarätter",
+    "price": "120:-",
+    "unit": null,
+    "description": "2x1000-1100 g • 60 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "60",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.4653&x2r=0.7117&y1r=0.4767&y2r=0.7303&s=c9710c191c1e58e098f932e2fed739ef"
   },
   {
     "store": "ICA Kvantum",
@@ -2472,22 +2412,12 @@
   {
     "store": "ICA Kvantum",
     "name": "Fryst hamburgare",
-    "price": "Medlemspris",
+    "price": "139:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.3729&x2r=0.6906&y1r=0.2224&y2r=0.5182&s=c5b53cece12331c7b8ed68cc847c59ea"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Frysta Thaiboxar",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.0618&x2r=0.3754&y1r=0.5095&y2r=0.7951&s=292ad27998e77355b903b5ee3dca7cc1"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-10.webp&w=300&x1r=0.6681&x2r=0.9661&y1r=0.256&y2r=0.4504&s=9e1a6ca8edad3904fe6daea436e36fae"
   },
   {
     "store": "ICA Kvantum",
@@ -2501,6 +2431,16 @@
   },
   {
     "store": "ICA Kvantum",
+    "name": "Frysta Thaiboxar",
+    "price": "89:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.0618&x2r=0.3754&y1r=0.5095&y2r=0.7951&s=292ad27998e77355b903b5ee3dca7cc1"
+  },
+  {
+    "store": "ICA Kvantum",
     "name": "Pulled beef taco",
     "price": "62.90:-",
     "unit": null,
@@ -2508,16 +2448,6 @@
     "ord_pris": null,
     "jfr_pris": "170,00",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-4.webp&w=300&x1r=0.3666&x2r=0.6639&y1r=0.5614&y2r=0.7674&s=053b34a4db254446b6905efcd37cf603"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Snabbkaffe refill",
-    "price": "169:-",
-    "unit": null,
-    "description": "2x200 g • 422,50 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "422,50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.0351&x2r=0.2752&y1r=0.7057&y2r=0.9404&s=ab173d4e15953ca5fc167ed805c5a3db"
   },
   {
     "store": "ICA Kvantum",
@@ -2531,6 +2461,16 @@
   },
   {
     "store": "ICA Kvantum",
+    "name": "Snabbkaffe refill",
+    "price": "169:-",
+    "unit": null,
+    "description": "2x200 g • 422,50 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "422,50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.0351&x2r=0.2752&y1r=0.7057&y2r=0.9404&s=ab173d4e15953ca5fc167ed805c5a3db"
+  },
+  {
+    "store": "ICA Kvantum",
     "name": "Smaksatta riskakor, majskakor",
     "price": "60:-",
     "unit": null,
@@ -2538,46 +2478,6 @@
     "ord_pris": null,
     "jfr_pris": "100",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-3.webp&w=300&x1r=0.6493&x2r=0.9534&y1r=0.4619&y2r=0.9469&s=dce36ad993cd93cb721eaada2abbd189"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Färsk pasta",
-    "price": "10:-",
-    "unit": null,
-    "description": "200-250 g • 50 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-1.webp&w=300&x1r=0.7182&x2r=0.9482&y1r=0.2264&y2r=0.4786&s=be9e6550dba649cf05c55446590e144f"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Flingor",
-    "price": "59:-",
-    "unit": null,
-    "description": "2x330-375 g • 89,39 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "89,39",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.4289&x2r=0.7123&y1r=0.2765&y2r=0.4715&s=01971c1c4fd083bbd1a739b26adb7d40"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Gulaschsoppa",
-    "price": "70:-",
-    "unit": null,
-    "description": "2x560 g • 62,50 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "62,50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.0257&x2r=0.2532&y1r=0.4815&y2r=0.7267&s=9044d5c8be752a5ed8d09df2371f0912"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Krossade tomater",
-    "price": "30:-",
-    "unit": null,
-    "description": "2x400 g • 37,50 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "37,50",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-2.webp&w=300&x1r=0.0549&x2r=0.3521&y1r=0.625&y2r=0.9479&s=d82dd208738ea20c95e56fb7a3f46fd1"
   },
   {
     "store": "ICA Kvantum",
@@ -2591,18 +2491,58 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Glutenfri pasta",
-    "price": "35:-",
+    "name": "Färsk pasta",
+    "price": "10:-",
     "unit": null,
-    "description": "2x400 g • 43,75 kr/kg",
+    "description": "200-250 g • 50 kr/kg",
     "ord_pris": null,
-    "jfr_pris": "43,75",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.2413&x2r=0.4816&y1r=0.4847&y2r=0.7326&s=2c48724368714d4274ed770872282d8a"
+    "jfr_pris": "50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-4.webp&w=300&x1r=0.6785&x2r=0.9755&y1r=0.792&y2r=0.9408&s=405712aa85b902889622be2061572ec4"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Flingor",
+    "price": "59:-",
+    "unit": null,
+    "description": "2x330-375 g • 89,39 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "89,39",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.4289&x2r=0.7123&y1r=0.2765&y2r=0.4715&s=01971c1c4fd083bbd1a739b26adb7d40"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Krossade tomater",
+    "price": "30:-",
+    "unit": null,
+    "description": "2x400 g • 37,50 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "37,50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-2.webp&w=300&x1r=0.0549&x2r=0.3521&y1r=0.625&y2r=0.9479&s=d82dd208738ea20c95e56fb7a3f46fd1"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Gulaschsoppa",
+    "price": "70:-",
+    "unit": null,
+    "description": "2x560 g • 62,50 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "62,50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-5.webp&w=300&x1r=0.0257&x2r=0.2532&y1r=0.4815&y2r=0.7267&s=9044d5c8be752a5ed8d09df2371f0912"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "MAJS",
+    "price": "19.95:-",
+    "unit": null,
+    "description": "480 g • 41,56 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "41,56",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FtaWdWBX0%2Fp-1.webp&w=300&x1r=0.0187&x2r=0.6613&y1r=0.1608&y2r=0.3464&s=f929a8075fe860ccf2f94999b7fd23cd"
   },
   {
     "store": "ICA Kvantum",
     "name": "Läsk",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -2612,7 +2552,7 @@
   {
     "store": "ICA Kvantum",
     "name": "Kolsyrat vatten",
-    "price": "Medlemspris",
+    "price": "28:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -2671,16 +2611,6 @@
   },
   {
     "store": "ICA Kvantum",
-    "name": "Rosta",
-    "price": "15:-",
-    "unit": null,
-    "description": "450 g • 33,33 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "33,33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.7039&x2r=0.9618&y1r=0.0615&y2r=0.2829&s=5ddd37302a4bc7df76e11fc7414027fd"
-  },
-  {
-    "store": "ICA Kvantum",
     "name": "Hamburgerbröd",
     "price": "15:-",
     "unit": null,
@@ -2688,6 +2618,16 @@
     "ord_pris": null,
     "jfr_pris": "50",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-4.webp&w=300&x1r=0.3645&x2r=0.6677&y1r=0.7491&y2r=0.9395&s=bca3c6e48eb4247d773b2aaaa99a89a1"
+  },
+  {
+    "store": "ICA Kvantum",
+    "name": "Rosta",
+    "price": "15:-",
+    "unit": null,
+    "description": "450 g • 33,33 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "33,33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-9.webp&w=300&x1r=0.7039&x2r=0.9618&y1r=0.0615&y2r=0.2829&s=5ddd37302a4bc7df76e11fc7414027fd"
   },
   {
     "store": "ICA Kvantum",
@@ -2722,22 +2662,22 @@
   {
     "store": "ICA Kvantum",
     "name": "Toalettpapper, Hushållspapper Classic",
-    "price": "Medlemspris",
+    "price": "95:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.3557&x2r=0.6586&y1r=0.516&y2r=0.7938&s=cd1d53af975fe6b3013f5439021c5a28"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-10.webp&w=300&x1r=0.0638&x2r=0.3723&y1r=0.6712&y2r=0.9389&s=41253a505b299493038592ccba8db9c1"
   },
   {
     "store": "ICA Kvantum",
     "name": "Flytande tvättmedel",
-    "price": "Medlemspris",
+    "price": "119:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-12.webp&w=300&x1r=0.6602&x2r=0.9715&y1r=0.515&y2r=0.7949&s=4bc830e530efa83c7325eeeac8b4ea09"
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-10.webp&w=300&x1r=0.3678&x2r=0.7299&y1r=0.667&y2r=0.9378&s=a33d855299a65991b8fbc2d4ba0bc185"
   },
   {
     "store": "ICA Kvantum",
@@ -2801,6 +2741,16 @@
   },
   {
     "store": "ICA Kvantum",
+    "name": "Schampo, balsam",
+    "price": "59:-",
+    "unit": null,
+    "description": "2x200-250 ml • 147,50 kr/l",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-11.webp&w=300&x1r=0.0312&x2r=0.3063&y1r=0.0519&y2r=0.3254&s=371c3f19f96b2f8c516a1af7a291ce75"
+  },
+  {
+    "store": "ICA Kvantum",
     "name": "Hårfärg, Root concealer",
     "price": "149:-",
     "unit": null,
@@ -2822,22 +2772,12 @@
   {
     "store": "ICA Kvantum",
     "name": "Apolosophy Hair",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-6.webp&w=300&x1r=0.5207&x2r=0.9557&y1r=0.6641&y2r=0.897&s=01962ebee7db0af30089d746001bb89c"
-  },
-  {
-    "store": "ICA Kvantum",
-    "name": "Schampo, balsam",
-    "price": "59:-",
-    "unit": null,
-    "description": "2x200-250 ml • 147,50 kr/l",
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FUyNKFHOS%2Fp-11.webp&w=300&x1r=0.0312&x2r=0.3063&y1r=0.0519&y2r=0.3254&s=371c3f19f96b2f8c516a1af7a291ce75"
   },
   {
     "store": "ICA Kvantum",
@@ -2901,18 +2841,8 @@
   },
   {
     "store": "Stora Coop",
-    "name": "Kommande",
-    "price": "9:-",
-    "unit": null,
-    "description": "500 g • 18 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "18",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fss8eM4ao%2Fp-3.webp&w=300&x1r=0.651&x2r=0.9501&y1r=0.4734&y2r=0.8501&s=c3bc64e2b6e2da3b3ebd0d0c9e5b3873"
-  },
-  {
-    "store": "Stora Coop",
     "name": "Gröna druvor",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -2931,16 +2861,6 @@
   },
   {
     "store": "Stora Coop",
-    "name": "Blomkål",
-    "price": "25:-",
-    "unit": null,
-    "description": "1 kg • 25 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "25",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-5.webp&w=300&x1r=0.5606&x2r=0.9556&y1r=0.0314&y2r=0.2734&s=1b0cc750c564e8cef3fb78a9839aa68b"
-  },
-  {
-    "store": "Stora Coop",
     "name": "Mango",
     "price": "30:-",
     "unit": null,
@@ -2948,6 +2868,26 @@
     "ord_pris": null,
     "jfr_pris": "45,45",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-5.webp&w=300&x1r=0.6003&x2r=0.9465&y1r=0.6374&y2r=0.8903&s=f40369639527346f639d23da874834a7"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Kommande",
+    "price": "9:-",
+    "unit": null,
+    "description": "500 g • 18 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "18",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fss8eM4ao%2Fp-3.webp&w=300&x1r=0.651&x2r=0.9501&y1r=0.4734&y2r=0.8501&s=c3bc64e2b6e2da3b3ebd0d0c9e5b3873"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Blomkål",
+    "price": "25:-",
+    "unit": null,
+    "description": "1 kg • 25 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "25",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-5.webp&w=300&x1r=0.5606&x2r=0.9556&y1r=0.0314&y2r=0.2734&s=1b0cc750c564e8cef3fb78a9839aa68b"
   },
   {
     "store": "Stora Coop",
@@ -3002,7 +2942,7 @@
   {
     "store": "Stora Coop",
     "name": "Kycklinglårfilé",
-    "price": "Medlemspris",
+    "price": "129:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3012,22 +2952,12 @@
   {
     "store": "Stora Coop",
     "name": "Kebab/Falafel/Gyros",
-    "price": "Medlemspris",
+    "price": "99:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-3.webp&w=300&x1r=0.0643&x2r=0.6507&y1r=0.1982&y2r=0.522&s=e84fdacc1ada66cff94e4e90dc833bb1"
-  },
-  {
-    "store": "Stora Coop",
-    "name": "Bacon",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-3.webp&w=300&x1r=0.0468&x2r=0.389&y1r=0.6539&y2r=0.7985&s=c45ab09362a7e911d9e8c5b8f5fd2351"
   },
   {
     "store": "Stora Coop",
@@ -3038,6 +2968,16 @@
     "ord_pris": null,
     "jfr_pris": "289",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-4.webp&w=300&x1r=0.5669&x2r=0.944&y1r=0.5898&y2r=0.7416&s=53a338ab28675548191f3d8e4f3d7a69"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Handskalade räkor",
+    "price": "89:-",
+    "unit": null,
+    "description": "240 g • 370,83 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "370,83",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-4.webp&w=300&x1r=0.5599&x2r=0.8632&y1r=0.727&y2r=0.8791&s=798bcee9a4ea0a15a73b815a55dc64d1"
   },
   {
     "store": "Stora Coop",
@@ -3052,7 +2992,7 @@
   {
     "store": "Stora Coop",
     "name": "Havremjölk",
-    "price": "Medlemspris",
+    "price": "40:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3072,7 +3012,7 @@
   {
     "store": "Stora Coop",
     "name": "Riven ost",
-    "price": "Medlemspris",
+    "price": "40:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3082,7 +3022,7 @@
   {
     "store": "Stora Coop",
     "name": "Gräddfil",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3101,6 +3041,16 @@
   },
   {
     "store": "Stora Coop",
+    "name": "Yoghurt",
+    "price": "46:-",
+    "unit": null,
+    "description": "2x1000 g • 23 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "23",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-6.webp&w=300&x1r=0.0565&x2r=0.3559&y1r=0.4395&y2r=0.6331&s=88fdf061f9345e197e762ab1ec9dd849"
+  },
+  {
+    "store": "Stora Coop",
     "name": "Vegetariskt pålägg",
     "price": "20:-",
     "unit": null,
@@ -3112,7 +3062,7 @@
   {
     "store": "Stora Coop",
     "name": "Smörgåspålägg",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3152,7 +3102,7 @@
   {
     "store": "Stora Coop",
     "name": "Matpaj",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3172,22 +3122,12 @@
   {
     "store": "Stora Coop",
     "name": "Tex mex",
-    "price": "Medlemspris",
+    "price": "50:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-3.webp&w=300&x1r=0.3653&x2r=0.665&y1r=0.525&y2r=0.7485&s=b656e28c8677555ac7b12dca5724d2ae"
-  },
-  {
-    "store": "Stora Coop",
-    "name": "Granola",
-    "price": "75:-",
-    "unit": null,
-    "description": "2x375 g • 100 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "100",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-6.webp&w=300&x1r=0.3417&x2r=0.6994&y1r=0.4712&y2r=0.6355&s=4685f24be8c102a57d90772cf9794b4a"
   },
   {
     "store": "Stora Coop",
@@ -3198,6 +3138,16 @@
     "ord_pris": null,
     "jfr_pris": "267,86",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-3.webp&w=300&x1r=0.0541&x2r=0.3714&y1r=0.5262&y2r=0.6728&s=486cb4c96f769d9ff4dd0dcea30a3c0d"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Granola",
+    "price": "75:-",
+    "unit": null,
+    "description": "2x375 g • 100 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "100",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-6.webp&w=300&x1r=0.3417&x2r=0.6994&y1r=0.4712&y2r=0.6355&s=4685f24be8c102a57d90772cf9794b4a"
   },
   {
     "store": "Stora Coop",
@@ -3272,7 +3222,7 @@
   {
     "store": "Stora Coop",
     "name": "Snacks",
-    "price": "Medlemspris",
+    "price": "65:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3291,16 +3241,6 @@
   },
   {
     "store": "Stora Coop",
-    "name": "Choklad stycksaker",
-    "price": "25:-",
-    "unit": null,
-    "description": "3x37-60 g • 225,23 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "225,23",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-7.webp&w=300&x1r=0.5172&x2r=0.9465&y1r=0.021&y2r=0.2675&s=961f0666beeef73dc30fa3645e050d24"
-  },
-  {
-    "store": "Stora Coop",
     "name": "Chokladsnacks",
     "price": "49:-",
     "unit": null,
@@ -3308,6 +3248,16 @@
     "ord_pris": null,
     "jfr_pris": "272,22",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-7.webp&w=300&x1r=0.0329&x2r=0.6177&y1r=0.0201&y2r=0.4553&s=78717e4e9d580cc82bb65b833b744725"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Choklad stycksaker",
+    "price": "25:-",
+    "unit": null,
+    "description": "3x37-60 g • 225,23 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "225,23",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FnjyFppA3%2Fp-7.webp&w=300&x1r=0.5172&x2r=0.9465&y1r=0.021&y2r=0.2675&s=961f0666beeef73dc30fa3645e050d24"
   },
   {
     "store": "Stora Coop",
@@ -3338,6 +3288,16 @@
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fa2UE5dad%2Fp-16.webp&w=300&x1r=0.0415&x2r=0.4308&y1r=0.6308&y2r=0.9132&s=4485370fb6502886b442d2387ee20939"
+  },
+  {
+    "store": "Stora Coop",
+    "name": "Kökstextil",
+    "price": "29.90:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fa2UE5dad%2Fp-15.webp&w=300&x1r=0.4945&x2r=0.9892&y1r=0.477&y2r=0.9256&s=db33cecd19dbaa30825fbeb92c009eab"
   },
   {
     "store": "Stora Coop",
@@ -3398,16 +3358,6 @@
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fa2UE5dad%2Fp-15.webp&w=300&x1r=0.0416&x2r=0.5&y1r=0.6498&y2r=0.7941&s=f57c13cbbb0369c63ad77570a749dfe0"
-  },
-  {
-    "store": "Stora Coop",
-    "name": "Glasunderlägg 4-pack",
-    "price": "29.90:-",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fa2UE5dad%2Fp-15.webp&w=300&x1r=0.0363&x2r=0.5293&y1r=0.7787&y2r=0.9178&s=8f390b5b957b46799a86575701eec04e"
   },
   {
     "store": "Stora Coop",
@@ -3592,7 +3542,7 @@
   {
     "store": "Coop",
     "name": "Gröna druvor",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3621,6 +3571,16 @@
   },
   {
     "store": "Coop",
+    "name": "Frysta grönsaker",
+    "price": "49:-",
+    "unit": null,
+    "description": "3x400-500 g • 40,83 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "40,83",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FwXxBfvoC%2Fp-2.webp&w=300&x1r=0.329&x2r=0.6589&y1r=0.4697&y2r=0.7132&s=58ccc3cdc158df6f0acbc077641b423f"
+  },
+  {
+    "store": "Coop",
     "name": "Ekologisk sallad i påse",
     "price": "30:-",
     "unit": null,
@@ -3641,16 +3601,6 @@
   },
   {
     "store": "Coop",
-    "name": "Frysta grönsaker",
-    "price": "49:-",
-    "unit": null,
-    "description": "3x400-500 g • 40,83 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "40,83",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FwXxBfvoC%2Fp-2.webp&w=300&x1r=0.329&x2r=0.6589&y1r=0.4697&y2r=0.7132&s=58ccc3cdc158df6f0acbc077641b423f"
-  },
-  {
-    "store": "Coop",
     "name": "Champinjoner",
     "price": "30:-",
     "unit": null,
@@ -3662,7 +3612,7 @@
   {
     "store": "Coop",
     "name": "Färsk kycklingfilé",
-    "price": "Medlemspris",
+    "price": "79:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3701,8 +3651,18 @@
   },
   {
     "store": "Coop",
+    "name": "Färsk biff",
+    "price": "59.90:-",
+    "unit": null,
+    "description": "180 g • 332,78 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "332,78",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FBcO3S8Zx%2Fp-2.webp&w=300&x1r=0.6434&x2r=0.9938&y1r=0.7103&y2r=0.9564&s=72abe87708d7d43f4e4c5c651fda283d"
+  },
+  {
+    "store": "Coop",
     "name": "Svenskt smör",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3762,7 +3722,7 @@
   {
     "store": "Coop",
     "name": "Glass",
-    "price": "Medlemspris",
+    "price": "99:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3772,22 +3732,12 @@
   {
     "store": "Coop",
     "name": "Pizza",
-    "price": "Medlemspris",
+    "price": "85:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FXJpi94g0%2Fp-4.webp&w=300&x1r=0.6426&x2r=0.9596&y1r=0.7034&y2r=0.9179&s=263124b9f7f35ae639f51fdd89cb538a"
-  },
-  {
-    "store": "Coop",
-    "name": "Vegetariskt protein",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FXJpi94g0%2Fp-4.webp&w=300&x1r=0.6378&x2r=0.9702&y1r=0.0182&y2r=0.2544&s=e81a5ef3303d78cc966a69cdec9251c2"
   },
   {
     "store": "Coop",
@@ -3801,8 +3751,18 @@
   },
   {
     "store": "Coop",
+    "name": "Vegetariskt protein",
+    "price": "99:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FXJpi94g0%2Fp-4.webp&w=300&x1r=0.6378&x2r=0.9702&y1r=0.0182&y2r=0.2544&s=e81a5ef3303d78cc966a69cdec9251c2"
+  },
+  {
+    "store": "Coop",
     "name": "Matpaj",
-    "price": "Medlemspris",
+    "price": "55:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3832,7 +3792,7 @@
   {
     "store": "Coop",
     "name": "Kaffe",
-    "price": "Medlemspris",
+    "price": "109:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3852,7 +3812,7 @@
   {
     "store": "Coop",
     "name": "Tex-mex",
-    "price": "Medlemspris",
+    "price": "50:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3891,6 +3851,16 @@
   },
   {
     "store": "Coop",
+    "name": "Nötter",
+    "price": "49:-",
+    "unit": null,
+    "description": "2x150-300 g • 163,33 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "163,33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FXJpi94g0%2Fp-6.webp&w=300&x1r=0.6479&x2r=0.9614&y1r=0.4763&y2r=0.695&s=c7f23e7292dd0310f07e6c7609e5584c"
+  },
+  {
+    "store": "Coop",
     "name": "Läsk",
     "price": "35:-",
     "unit": null,
@@ -3922,7 +3892,7 @@
   {
     "store": "Coop",
     "name": "Baguette",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -3961,16 +3931,6 @@
   },
   {
     "store": "Coop",
-    "name": "Chokladkakor",
-    "price": "35:-",
-    "unit": null,
-    "description": "100 g • 350,00 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "350,00",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FWlt1ICpk%2Fp-2.webp&w=300&x1r=0.0262&x2r=0.4944&y1r=0.4483&y2r=0.8023&s=6b246795941921dec0ee93679cae9b22"
-  },
-  {
-    "store": "Coop",
     "name": "Snacks",
     "price": "55:-",
     "unit": null,
@@ -3978,6 +3938,16 @@
     "ord_pris": null,
     "jfr_pris": "785,71",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FXJpi94g0%2Fp-6.webp&w=300&x1r=0.0399&x2r=0.6518&y1r=0.0442&y2r=0.468&s=f895250594bcd3cd978da53e8d33ee9b"
+  },
+  {
+    "store": "Coop",
+    "name": "Chokladkakor",
+    "price": "35:-",
+    "unit": null,
+    "description": "100 g • 350,00 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "350,00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FWlt1ICpk%2Fp-2.webp&w=300&x1r=0.0262&x2r=0.4944&y1r=0.4483&y2r=0.8023&s=6b246795941921dec0ee93679cae9b22"
   },
   {
     "store": "Coop",
@@ -3992,7 +3962,7 @@
   {
     "store": "Coop",
     "name": "Kex TUC",
-    "price": "Medlemspris",
+    "price": "20:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4061,6 +4031,16 @@
   },
   {
     "store": "Willys",
+    "name": "GRÖNA VINDRUVOR 500G",
+    "price": "29.90:-",
+    "unit": null,
+    "description": "500 g • 59,80 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "59,80",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-8.webp&w=300&x1r=0.5014&x2r=0.7475&y1r=0.5285&y2r=0.7916&s=3a55bcd71542e91db1b0577562359c01"
+  },
+  {
+    "store": "Willys",
     "name": "HEL SPETSKÅL",
     "price": "19.90:-",
     "unit": null,
@@ -4091,26 +4071,6 @@
   },
   {
     "store": "Willys",
-    "name": "ÄPPLE INGRID MARIE",
-    "price": "19.90:-",
-    "unit": null,
-    "description": "1 kg • 19,90 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "19,90",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-8.webp&w=300&x1r=0.7379&x2r=0.9911&y1r=0.5436&y2r=0.7953&s=07a8504e9144a9e51791f7de055d74d3"
-  },
-  {
-    "store": "Willys",
-    "name": "GRÖNA VINDRUVOR 500G",
-    "price": "29.90:-",
-    "unit": null,
-    "description": "500 g • 59,80 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "59,80",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-1.webp&w=300&x1r=0.4311&x2r=0.6398&y1r=0.6373&y2r=0.9276&s=661e2e8e4a4a5b6c2f94e555cc842d4b"
-  },
-  {
-    "store": "Willys",
     "name": "BLADPERSILJA 250G",
     "price": "19.90:-",
     "unit": null,
@@ -4121,8 +4081,18 @@
   },
   {
     "store": "Willys",
+    "name": "ÄPPLE INGRID MARIE",
+    "price": "19.90:-",
+    "unit": null,
+    "description": "1 kg • 19,90 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "19,90",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-8.webp&w=300&x1r=0.7379&x2r=0.9911&y1r=0.5436&y2r=0.7953&s=07a8504e9144a9e51791f7de055d74d3"
+  },
+  {
+    "store": "Willys",
     "name": "BLANDFÄRS",
-    "price": "Medlemspris",
+    "price": "89.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4132,7 +4102,7 @@
   {
     "store": "Willys",
     "name": "LÖVBIFF",
-    "price": "Medlemspris",
+    "price": "179:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4142,7 +4112,7 @@
   {
     "store": "Willys",
     "name": "HEL MAJSKYCKLING",
-    "price": "Medlemspris",
+    "price": "59.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4152,7 +4122,7 @@
   {
     "store": "Willys",
     "name": "LAXFILÉ 4-PACK",
-    "price": "Medlemspris",
+    "price": "79.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4162,7 +4132,7 @@
   {
     "store": "Willys",
     "name": "FÄRSK FLÄSKFILÉ",
-    "price": "Medlemspris",
+    "price": "79.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4172,7 +4142,7 @@
   {
     "store": "Willys",
     "name": "KYCKLINGBEN",
-    "price": "Medlemspris",
+    "price": "59.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4182,7 +4152,7 @@
   {
     "store": "Willys",
     "name": "FÄRSKA HAMBURGARE",
-    "price": "Medlemspris",
+    "price": "44.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4192,7 +4162,7 @@
   {
     "store": "Willys",
     "name": "VARMRÖKT REGNBÅGSLAX",
-    "price": "Medlemspris",
+    "price": "119:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4211,18 +4181,18 @@
   },
   {
     "store": "Willys",
-    "name": "LAXBURGARE 2-PACK",
-    "price": "Medlemspris",
+    "name": "SKIVAT BACON 5-PACK",
+    "price": "58.90:-",
     "unit": null,
-    "description": null,
+    "description": "5x100 g • 117,80 kr/kg",
     "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-2.webp&w=300&x1r=0.4663&x2r=0.7769&y1r=0.0109&y2r=0.2427&s=aad60a3cdf7cdcac96d62df125587032"
+    "jfr_pris": "117,80",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-2.webp&w=300&x1r=0.0156&x2r=0.2635&y1r=0.5999&y2r=0.9547&s=05b869add0c68e336f3c9c65b5b1663a"
   },
   {
     "store": "Willys",
     "name": "PRÄST®, HERRGÅRD®, GREVÉ",
-    "price": "Medlemspris",
+    "price": "79.80:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4232,7 +4202,7 @@
   {
     "store": "Willys",
     "name": "SMÖR",
-    "price": "Medlemspris",
+    "price": "49.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4242,7 +4212,7 @@
   {
     "store": "Willys",
     "name": "BREGOTT",
-    "price": "Medlemspris",
+    "price": "44.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4252,7 +4222,7 @@
   {
     "store": "Willys",
     "name": "EKOLOGISK HUMLAN",
-    "price": "Medlemspris",
+    "price": "89.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4262,7 +4232,7 @@
   {
     "store": "Willys",
     "name": "MOZZARELLA",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4282,7 +4252,7 @@
   {
     "store": "Willys",
     "name": "SMAKSATT CRÈME FRAICHE",
-    "price": "Medlemspris",
+    "price": "14.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4291,8 +4261,18 @@
   },
   {
     "store": "Willys",
+    "name": "MJUKOST",
+    "price": "34.80:-",
+    "unit": null,
+    "description": "230-275 g • 151,30 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "151,30",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-4.webp&w=300&x1r=0.4452&x2r=0.9089&y1r=0.4779&y2r=0.6451&s=c905f19a266c8bdbd2ec2978bdd78ba7"
+  },
+  {
+    "store": "Willys",
     "name": "HAMBURGEROST",
-    "price": "Medlemspris",
+    "price": "17.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4301,18 +4281,8 @@
   },
   {
     "store": "Willys",
-    "name": "OSTBRICKA",
-    "price": "64.90:-",
-    "unit": null,
-    "description": "155 g • 418,71 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "418,71",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-5.webp&w=300&x1r=0.6699&x2r=0.9932&y1r=0.7339&y2r=0.948&s=56c9ea1289518c6de0c32df3189f818c"
-  },
-  {
-    "store": "Willys",
     "name": "GRILLOST",
-    "price": "Medlemspris",
+    "price": "28:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4342,7 +4312,7 @@
   {
     "store": "Willys",
     "name": "BEEF BURGER",
-    "price": "Medlemspris",
+    "price": "99:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4391,6 +4361,16 @@
   },
   {
     "store": "Willys",
+    "name": "OVO VEGETARISKA MÅLTIDSDELAR",
+    "price": "49.90:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-6.webp&w=300&x1r=0.0073&x2r=0.3069&y1r=0.6527&y2r=0.9537&s=483c31f6289fc496431fef41a3e441a5"
+  },
+  {
+    "store": "Willys",
     "name": "MAJSKOLVAR",
     "price": "35:-",
     "unit": null,
@@ -4398,16 +4378,6 @@
     "ord_pris": null,
     "jfr_pris": "43,75",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-2.webp&w=300&x1r=0.5617&x2r=0.9854&y1r=0.5138&y2r=0.7009&s=555e32007617e1a3f2a2262e89b14096"
-  },
-  {
-    "store": "Willys",
-    "name": "OVO VEGETARISKA MÅLTIDSDELAR",
-    "price": "Medlemspris",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-6.webp&w=300&x1r=0.0073&x2r=0.3069&y1r=0.6527&y2r=0.9537&s=483c31f6289fc496431fef41a3e441a5"
   },
   {
     "store": "Willys",
@@ -4432,7 +4402,7 @@
   {
     "store": "Willys",
     "name": "FOND",
-    "price": "Medlemspris",
+    "price": "25.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4472,7 +4442,7 @@
   {
     "store": "Willys",
     "name": "KYLDA SÅSER",
-    "price": "Medlemspris",
+    "price": "14.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4492,7 +4462,7 @@
   {
     "store": "Willys",
     "name": "HAMBURGERGURKA",
-    "price": "Medlemspris",
+    "price": "23.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4522,7 +4492,7 @@
   {
     "store": "Willys",
     "name": "LÄSK",
-    "price": "Medlemspris",
+    "price": "25:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4542,7 +4512,7 @@
   {
     "store": "Willys",
     "name": "JUICE",
-    "price": "Medlemspris",
+    "price": "23.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4562,7 +4532,7 @@
   {
     "store": "Willys",
     "name": "BRIOCHE HAMBURGERBRÖD 4-PACK",
-    "price": "Medlemspris",
+    "price": "35:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4572,7 +4542,7 @@
   {
     "store": "Willys",
     "name": "PAVÉ NAPOLI",
-    "price": "Medlemspris",
+    "price": "14.90:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4602,7 +4572,7 @@
   {
     "store": "Willys",
     "name": "NATURGODIS",
-    "price": "Medlemspris",
+    "price": "149:-",
     "unit": null,
     "description": null,
     "ord_pris": null,
@@ -4621,16 +4591,6 @@
   },
   {
     "store": "Willys",
-    "name": "GODISPÅSAR",
-    "price": "39:-",
-    "unit": null,
-    "description": "3x120-170 g • 108,33 kr/kg",
-    "ord_pris": null,
-    "jfr_pris": "108,33",
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-5.webp&w=300&x1r=0.0085&x2r=0.2833&y1r=0.4419&y2r=0.689&s=e278bd67aea54f11ad94434887a7b8c9"
-  },
-  {
-    "store": "Willys",
     "name": "CHEEZ DOODLES",
     "price": "34.80:-",
     "unit": null,
@@ -4641,8 +4601,18 @@
   },
   {
     "store": "Willys",
+    "name": "GODISPÅSAR",
+    "price": "39:-",
+    "unit": null,
+    "description": "3x120-170 g • 108,33 kr/kg",
+    "ord_pris": null,
+    "jfr_pris": "108,33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-5.webp&w=300&x1r=0.0085&x2r=0.2833&y1r=0.4419&y2r=0.689&s=e278bd67aea54f11ad94434887a7b8c9"
+  },
+  {
+    "store": "Willys",
     "name": "TVÄTTMEDEL, SKÖLJMEDEL",
-    "price": "Medlemspris",
+    "price": "79:-",
     "unit": null,
     "description": "Max 3 st | För dig med WillysPlus. SPARA 31:70-58:70. VIA • COMFORT • 760g • 760-925ml Olika sorter • Jämförpris 0:431:39 kr/tvätt • Max 3 köp/hushåll Lägsta 30-dgrspris 36:90-44:90 kr. | Max 3 st | För dig med WillysPlus. SPARA 31:70-58:70. VIA • COMFORT • 760g • 760-925ml Olika sorter • Jämförpris 0:431:39 kr/tvätt • Max 3 köp/hushåll Lägsta 30-dgrspris 36:90-44:90 kr.",
     "ord_pris": "36:90-44:90",
@@ -4672,22 +4642,12 @@
   {
     "store": "Willys",
     "name": "BLÖJOR",
-    "price": "Medlemspris",
+    "price": "169:-",
     "unit": null,
     "description": "Max 2 st | För dig med WillysPlus. SPARA 57:00-69:00. PAMPERS • 26-42p • Olika sorter • Jämförpris 2:01-3:25 kr/st. Max 2 köp/hushåll. • Lägsta 30-dgrspris 113:00-119:00 kr. | Max 2 st | För dig med WillysPlus. SPARA 57:00-69:00. PAMPERS • 26-42p • Olika sorter • Jämförpris 2:01-3:25 kr/st. Max 2 köp/hushåll. • Lägsta 30-dgrspris 113:00-119:00 kr.",
     "ord_pris": "113:00-119:00",
     "jfr_pris": "25",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.6173&x2r=0.9915&y1r=0.4844&y2r=0.9401&s=19d766cb331d136f41f153cf2eccfc1e"
-  },
-  {
-    "store": "Willys",
-    "name": "MUNSKÖLJ",
-    "price": "24.90:-",
-    "unit": null,
-    "description": "500 ml • 49,80 kr/l",
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.28&x2r=0.5703&y1r=0.2566&y2r=0.5231&s=51869c11f8a2297547cfbbf8adf8b7ec"
   },
   {
     "store": "Willys",
@@ -4698,6 +4658,16 @@
     "ord_pris": null,
     "jfr_pris": null,
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.6893&x2r=0.9879&y1r=0.0021&y2r=0.2615&s=e831d5ac58ff7299d8f14e6987e056b3"
+  },
+  {
+    "store": "Willys",
+    "name": "MUNSKÖLJ",
+    "price": "24.90:-",
+    "unit": null,
+    "description": "500 ml • 49,80 kr/l",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.28&x2r=0.5703&y1r=0.2566&y2r=0.5231&s=51869c11f8a2297547cfbbf8adf8b7ec"
   },
   {
     "store": "Willys",
@@ -4721,16 +4691,6 @@
   },
   {
     "store": "Willys",
-    "name": "TANDBORSTE, TANDKRÄM",
-    "price": "28:-",
-    "unit": null,
-    "description": null,
-    "ord_pris": null,
-    "jfr_pris": null,
-    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.7303&x2r=0.9914&y1r=0.2555&y2r=0.4926&s=4fde458965928d8a316d8101f3fdb457"
-  },
-  {
-    "store": "Willys",
     "name": "BINDOR, TROSSKYDD",
     "price": "40:-",
     "unit": null,
@@ -4741,6 +4701,16 @@
   },
   {
     "store": "Willys",
+    "name": "TANDBORSTE, TANDKRÄM",
+    "price": "28:-",
+    "unit": null,
+    "description": null,
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.7303&x2r=0.9914&y1r=0.2555&y2r=0.4926&s=4fde458965928d8a316d8101f3fdb457"
+  },
+  {
+    "store": "Willys",
     "name": "TAMPONGER",
     "price": "67.90:-",
     "unit": null,
@@ -4748,5 +4718,1475 @@
     "ord_pris": "74:90-79:90",
     "jfr_pris": "26",
     "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2FyUuvPglg%2Fp-7.webp&w=300&x1r=0.2993&x2r=0.621&y1r=0.7468&y2r=0.9513&s=fa2f49770ef516436e6566d909b6f4e9"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Färsk kycklingfilé",
+    "price": "119:-",
+    "unit": "/kg",
+    "description": "Ca 925 g | Naturell | Kronfågel | Ord.pris 163:90 kr.",
+    "ord_pris": "163:90",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbc6cdf46c7d9947e3582c7d8ac0c6b4b&w=568&s=55798203b8c36ccc5e38979c53827913"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Fryst hamburgare",
+    "price": "139:-",
+    "unit": "2 för",
+    "description": "720 g | 8-pack | ICA | Max 1 köp/hushåll | Jfr pris 96:53/kg | Ord.pris 88:90 kr.",
+    "ord_pris": "88:90",
+    "jfr_pris": "96:53",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F1e4abb26ebc3fd0d2becce1017e9dd68&w=272&s=1bdab00deeca642eb26c8f33b6aa603b"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Flytande tvättmedel",
+    "price": "119:-",
+    "unit": "4 för",
+    "description": "880-920 ml | A+ | Max 1 köp/hushåll | Jfr pris 1:29-1:35/tvätt | Ord.pris 47:90-48:90 kr.",
+    "ord_pris": "47:90-48:90",
+    "jfr_pris": "1:29-1:35",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F705165b1e3dcd159a8b23b9a7b4fbc8a&w=272&s=c41f86d3b31a63b1d7661baf53c8fb43"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Cookies",
+    "price": "50:-",
+    "unit": "2 för",
+    "description": "132-184 g | Gäller: XL Cookies, Home style, Choko Moment, Choco Whoopies, Brownie, Brookie | Marabou | Jfr pris 135:87-189:39/kg | Ord.pris 33:90-37:90 kr.",
+    "ord_pris": "33:90-37:90",
+    "jfr_pris": "135:87-189:39",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F32501a3f6b3c222b6c2766b1af192064&w=288&s=dc88d9b75a5b2378dc2576724b685d17"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Cognacsmedwurst",
+    "price": "169:-",
+    "unit": "/kg",
+    "description": "Ord.pris 219:00 kr.",
+    "ord_pris": "219:00",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-stg-assets%2Fuploads%2F9cb4wA%2FVUdcMn99wJxFpuoeXECEt&w=127&s=5c68c34c0d9adc19869a05e54174150f"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Röda kärnfria druvor i ask",
+    "price": "30:-",
+    "unit": "/st",
+    "description": "500 g | Klass 1 | ICA | Jfr pris 60:00/kg | Ord.pris 39:90 kr.",
+    "ord_pris": "39:90",
+    "jfr_pris": "60:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F13e970b11f58bed03a7aff22ca8e2655&w=276&s=1b2a2c4b201a8aec2084577895c76ebd"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Tulpaner 12-pack",
+    "price": "99:-",
+    "unit": "/st",
+    "description": "Flera färger. 3 kr går till Glada Hudik | ICA | Jfr pris 99:00/st | Ord.pris 119:90 kr.",
+    "ord_pris": "119:90",
+    "jfr_pris": "99:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4a2bdd3edaa948f6b62cb5d8344b0b99&w=176&s=0dace4a07d1c37db5dbfbd76471d9378"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Yoghurt",
+    "price": "45:-",
+    "unit": "2 för",
+    "description": "1000 g | Gäller Original och Mini. Gäller ej laktosfri | Yoggi | Jfr pris 22:50/kg | Ord.pris 28:90-29:90 kr.",
+    "ord_pris": "28:90-29:90",
+    "jfr_pris": "22:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdb48f5526a71957ba588cca3f850b9f9&w=176&s=f7efe16bd51a0d69f7764b7beb9aee53"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Schampo, balsam",
+    "price": "55:-",
+    "unit": "2 för",
+    "description": "200-250 ml | Elvital | Jfr pris 110:00-137:50/liter | Ord.pris 40:90 kr.",
+    "ord_pris": "40:90",
+    "jfr_pris": "110:00-137:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Ff4089f049893a20805cd31fd0b297ac8&w=176&s=f0cd6eb852f9a6017636fac7dc2f44bb"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Räkor med skal 90/120",
+    "price": "79:-",
+    "unit": "2 för",
+    "description": "400 g | Fryst | Royal Greenland | Jfr pris 98:75/kg | Ord.pris 55:90 kr.",
+    "ord_pris": "55:90",
+    "jfr_pris": "98:75",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fe3b2f519f6e88461b017bdf084f6dce3&w=276&s=da51616d93aec780ee7d424353ea2d76"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Renskav",
+    "price": "75:-",
+    "unit": "/st",
+    "description": "240 g | Lapin Liha | Max 2 köp/hushåll | Jfr pris 312:50/kg | Ord.pris 86:90 kr. 30dgr.pris 86:90 kr.",
+    "ord_pris": "86:90",
+    "jfr_pris": "312:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F1eb2b17fedd0ebb42e94e294fba0d323&w=276&s=a2b8f4e2e6dbcf442b26c85bbded1055"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Vegetariska produkter",
+    "price": "55:-",
+    "unit": "2 för",
+    "description": "220-320 g | Fryst. Gäller Färs, Filè, Bitar, Lasagne | Quorn | Jfr pris 85:94-125:00/kg | Ord.pris 37:90-43:90 kr.",
+    "ord_pris": "37:90-43:90",
+    "jfr_pris": "85:94-125:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F90795f3429010bf7dd3fefe54ba11173&w=276&s=3d83c2b5642c5291fad7233f19638b25"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Panpizza",
+    "price": "95:-",
+    "unit": "/st",
+    "description": "1530 g | Storpack Fryst | Billys | Max 2 köp/hushåll | Jfr pris 62:09/kg | Ord.pris 110:90 kr. 30dgr.pris 95:00 kr.",
+    "ord_pris": "110:90",
+    "jfr_pris": "62:09",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fffff5a0547d877c2a2d01bbb1920a12a&w=276&s=6716f7e90e5672a190898412d18675ea"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Levainbröd",
+    "price": "30:-",
+    "unit": "/st",
+    "description": "650 g | Gäller råg- och vetelevain | Pågen | Jfr pris 46:15/kg | Ord.pris 40:90 kr.",
+    "ord_pris": "40:90",
+    "jfr_pris": "46:15",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdf64e3e6b34ee3524573b8150f4ca20b&w=276&s=e1ea902cea9a6ca840eddbf4cddb80f5"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Majs-, Riskakor",
+    "price": "35:-",
+    "unit": "2 för",
+    "description": "120-125 g | Gäller ej tunna och ekologiska | Friggs | Jfr pris 140:00-145:83/kg | Ord.pris 22:90 kr.",
+    "ord_pris": "22:90",
+    "jfr_pris": "140:00-145:83",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4e143ad28ec3305230865d562798341a&w=276&s=24dfa05210b86509351881448ad911b4"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Frysta Thaiboxar",
+    "price": "89:-",
+    "unit": "3 för",
+    "description": "300-350 g | Kitchen Joy | Jfr pris 84:76-98:89/kg | Ord.pris 41:90 kr.",
+    "ord_pris": "41:90",
+    "jfr_pris": "84:76-98:89",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fc412ff45e9f72f3c87b0e20bff3838ff&w=276&s=bde15bf38998cf215ed8229fc984089d"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Ätklara kycklingdelar",
+    "price": "69:-",
+    "unit": "2 för",
+    "description": "350-500 g | Fryst. Gäller ej salladskyckling och kycklingspett bbq | Guldfågeln | Jfr pris 69:00-98:57/kg | Ord.pris 42:90 kr.",
+    "ord_pris": "42:90",
+    "jfr_pris": "69:00-98:57",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4bd0612fbea50cd0973da7b18f07a728&w=276&s=10279f604ddc5983029fe2d57b4672ef"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Dagens Enportionsrätter",
+    "price": "60:-",
+    "unit": "2 för",
+    "description": "340-400 g | Fryst. Flera olika sorter | Findus | Jfr pris 75:00-88:24/kg | Ord.pris 37:90 kr.",
+    "ord_pris": "37:90",
+    "jfr_pris": "75:00-88:24",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Ff058ead86bb2c1720446d2128b0c3af2&w=276&s=e0730a83d5d9e42124336742e5e52e7b"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Gräddglass, Sorbet",
+    "price": "30:-",
+    "unit": "2 för",
+    "description": "0,5 liter | Gäller ej Finaste | SIA Glass | Jfr pris 30:00/liter | Ord.pris 20:90-22:90 kr.",
+    "ord_pris": "20:90-22:90",
+    "jfr_pris": "30:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F37b5f203f1f78842ce832c72505a5dc6&w=276&s=1983f124225316f2e0699b4dcf0d308f"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Falukorv",
+    "price": "69:-",
+    "unit": "2 för",
+    "description": "800 g | Scan | Max 1 köp/hushåll | Jfr pris 43:12/kg | Ord.pris 40:90 kr.",
+    "ord_pris": "40:90",
+    "jfr_pris": "43:12",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fc565c59956f8ab34e5e906b665f13e12&w=276&s=6dd974f4b33702d58286fa796e18a3a8"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Grevé®, Herrgård®, Präst®, Rike®, Ära®",
+    "price": "79:-",
+    "unit": "/st",
+    "description": "670 g | 28-35%. Mildlagrad | Skånemejerier | Jfr pris 117:91/kg | Ord.pris 92:90 kr.",
+    "ord_pris": "92:90",
+    "jfr_pris": "117:91",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F4c8a9a7088268c83673ee4d38ba15475&w=276&s=6651e73eb98b88d20c0ac2d10432a76a"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Basturökt skinka",
+    "price": "269:-",
+    "unit": "/kg",
+    "description": "Från vår manuella | Lönneberga | Ord.pris 309:00 kr.",
+    "ord_pris": "309:00",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F22d7b3eeb73a324f5beb6780ae90d49e&w=276&s=c8b296d224d7e6a3497a62e12f58613d"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Skinkstek",
+    "price": null,
+    "unit": "/kg",
+    "description": "Ca 1100 g | ICA | Max 2 köp/hushåll | Ord.pris 97:90 kr.",
+    "ord_pris": "97:90",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F5e81e74988d197818f51f94cd35e8f3d&w=276&s=ee9200358420b929f56bb5e9d78344da"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Broccoli",
+    "price": "15:-",
+    "unit": "/st",
+    "description": "500 g | Klass 1 | ICA | Jfr pris 30:00/kg | Ord.pris 28:90 kr.",
+    "ord_pris": "28:90",
+    "jfr_pris": "30:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F59a43c753781d2e8cc8f8c7d40bd5566&w=276&s=9a211c7d10b86174170d4e9edcfb6f0d"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Babyplommontomater i ask",
+    "price": "25:-",
+    "unit": "/st",
+    "description": "500 g | Klass 1 | ICA | Jfr pris 50:00/kg | Ord.pris 37:90 kr.",
+    "ord_pris": "37:90",
+    "jfr_pris": "50:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F2f0b89b9b00b5e2bce930fc1f3ff432c&w=276&s=fe9b62d0866873e0e3a75dfc049561f2"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Blodapelsiner i nät",
+    "price": "20:-",
+    "unit": "/st",
+    "description": "1 kg | Klass 1 | ICA | Jfr pris 20:00/kg | Ord.pris 29:90-31:90 kr.",
+    "ord_pris": "29:90-31:90",
+    "jfr_pris": "20:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-stg-assets%2Fuploads%2F9cb4wA%2FVUdcMn99wJxFpuoeXECEt&w=127&s=5c68c34c0d9adc19869a05e54174150f"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Avokado",
+    "price": "20:-",
+    "unit": "2 för",
+    "description": "165 g | Klass 1 | Spanien/Marocko/Chile | Jfr pris 55:56/kg | Ord.pris 13:90 kr.",
+    "ord_pris": "13:90",
+    "jfr_pris": "55:56",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Ff107f0c734ad2443780e57afdcce8b72&w=276&s=1c6bdf595756ebf29586b142b96b997c"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Svenska äpplen",
+    "price": "20:-",
+    "unit": "/kg",
+    "description": "Klass 1. Flera sorter | ICA | Ord.pris 27:90-30:90 kr.",
+    "ord_pris": "27:90-30:90",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbf2e7746f1f22dc84c49733914afa703&w=276&s=1758f994da6eadd070709fa512057721"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Köttbullar",
+    "price": "69:-",
+    "unit": "/st",
+    "description": "1000 g | Kylda | Scan | Max 2 köp/hushåll | Jfr pris 69:00/kg | Ord.pris 79:90 kr.",
+    "ord_pris": "79:90",
+    "jfr_pris": "69:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F580b05d3c0e669fd8e209463159c42a8&w=276&s=2f2c9609846165a75058ea6b5cf20255"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Smörgåsmat",
+    "price": "20:-",
+    "unit": "/st",
+    "description": "90-105 g | Plånbokspackad. Gäller ej basturökt kalkon | Lönneberga | Jfr pris 190:48-222:22/kg | Ord.pris 29:90 kr.",
+    "ord_pris": "29:90",
+    "jfr_pris": "190:48-222:22",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fd9b887d0d87d70b57f12619c393d4961&w=276&s=087594405d9a8889fa973768f4475dee"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Skinkschnitzel",
+    "price": null,
+    "unit": "/st",
+    "description": "300 g | ICA | Jfr pris 156:33/kg | Ord.pris 53:90 kr.",
+    "ord_pris": "53:90",
+    "jfr_pris": "156:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F55c23989ce2ac758ee3c171bbf935d63&w=276&s=54703ebfa7137c332d9b8bfa57e61b21"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Färskost",
+    "price": "40:-",
+    "unit": "2 för",
+    "description": "145-200 g | Flera olika sorter | Philadelphia | Jfr pris 100:00-137:93/kg | Ord.pris 25:90-32:90 kr.",
+    "ord_pris": "25:90-32:90",
+    "jfr_pris": "100:00-137:93",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F013ecf464aa616bca9e2a265b2ef07b3&w=276&s=ee2a7e67f7b67205c4d29fddf4135acd"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Västerbottensost®",
+    "price": "89:-",
+    "unit": "/st",
+    "description": "450 g | Norrmejerier | Max 2 köp/hushåll | Jfr pris 197:78/kg | Ord.pris 111:90 kr.",
+    "ord_pris": "111:90",
+    "jfr_pris": "197:78",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fa04c4c28047f61553b21aaefa051cc78&w=276&s=d887965913f980a8b5918bfcff36c2ef"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Bacon, Stekfläsk",
+    "price": "115:-",
+    "unit": "/st",
+    "description": "1000 g | Skivat | Tulip | Jfr pris 115:00/kg | Ord.pris 141:90-154:90 kr.",
+    "ord_pris": "141:90-154:90",
+    "jfr_pris": "115:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F42c8de58ac723092a395ea4c61d2ea28&w=276&s=7aac5fbacb522095fbe0b2d41392329b"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Pannkakor",
+    "price": "20:-",
+    "unit": "/st",
+    "description": "200-240 g | Flera olika sorter | POP! Bakery | Jfr pris 83:33-100:00/kg | Ord.pris 26:90-30:90 kr.",
+    "ord_pris": "26:90-30:90",
+    "jfr_pris": "83:33-100:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fe512690c8ebe0f84abc53fb0c4a6bbb8&w=572&s=df9e266790589f70eccc99b81dc7eacf"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Spareribs",
+    "price": null,
+    "unit": "/kg",
+    "description": "Ca 1200 g | ICA | Ord.pris 82:90 kr.",
+    "ord_pris": "82:90",
+    "jfr_pris": null,
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F09f2db66c9f2a54b39207c77c4627ecb&w=276&s=8213a96ea9a83623b6b07a256b45ac61"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Umamifärs",
+    "price": null,
+    "unit": "/st",
+    "description": "500 g | Kryddad fläskfärs. Max 20% fetthalt. | ICA | Jfr pris 79:80/kg | Ord.pris 50:90 kr.",
+    "ord_pris": "50:90",
+    "jfr_pris": "79:80",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fef1f8fb2fb940453763fae240c405e05&w=276&s=633a604afe40f9f1425ffd13e937ece1"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Duschtvål",
+    "price": "34:-",
+    "unit": "2 för",
+    "description": "250 ml | Gäller ej Ren baby | Barnängen | Jfr pris 68:00/l | Ord.pris 22:90-24:90 kr.",
+    "ord_pris": "22:90-24:90",
+    "jfr_pris": "68:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fd97c6b10ab681dda2afbd6358310803f&w=572&s=d72fa26a6536cad0df106725f6c8326a"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Batterier",
+    "price": "69:-",
+    "unit": "2 för",
+    "description": "10-pack | Finns som AA och AAA | ICA | Jfr pris 3:45/st | Ord.pris 42:90 kr.",
+    "ord_pris": "42:90",
+    "jfr_pris": "3:45",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F200ec064e01a69b79e0ad6a6bb4a3ddf&w=572&s=c497563ee6a29cd519485cae0655fc17"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Crème Fraiche",
+    "price": "24:-",
+    "unit": "2 för",
+    "description": "2 dl | Naturell. Gäller även eko och laktosfri | Arla, Arla Köket | Jfr pris 60:00/liter | Ord.pris 14:90-20:90 kr.",
+    "ord_pris": "14:90-20:90",
+    "jfr_pris": "60:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fe4a5a2d3f12bd5bb2c2bf0ae99a7f4c1&w=276&s=a40012f70d339ca8c265924c0ce713f5"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Juice",
+    "price": "40:-",
+    "unit": "/st",
+    "description": "1,75-2 liter | Flera olika sorter, även Nektar Apelsin. Gäller ej Apelsinjuice. | Bravo | Jfr pris 20:00-22:86/liter | Ord.pris 47:90-48:90 kr.",
+    "ord_pris": "47:90-48:90",
+    "jfr_pris": "20:00-22:86",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F17d455967f172b39cb6fd5469d594383&w=276&s=6fda1c6e069f8b5164d9106dcf6745a2"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Risi-, Mannafrutti",
+    "price": "40:-",
+    "unit": "4 för",
+    "description": "165-175 g | Gäller även vegansk & laktosfri | Risifrutti | Max 1 köp/hushåll | Jfr pris 57:14-60:61/kg | Ord.pris 13:90-15:90 kr.",
+    "ord_pris": "13:90-15:90",
+    "jfr_pris": "57:14-60:61",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fd1377badbcdd2705d0c0ea91ea128379&w=276&s=fe31191dd5ba886d8e33cff5da2f8a63"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Toalettpapper, Hushållspapper Classic",
+    "price": "95:-",
+    "unit": "3 för",
+    "description": "8-pack, 4-pack | Lambi | Jfr pris 40:81-65:43/kg | Ord.pris 40:90-54:90 kr.",
+    "ord_pris": "40:90-54:90",
+    "jfr_pris": "40:81-65:43",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F221726ffd059771428f05bbe9d500067&w=276&s=4377e5fc9c1785567fa65b8129b219f2"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Fond",
+    "price": "60:-",
+    "unit": "2 för",
+    "description": "180 ml | Gäller ej Eko | Touch of taste | Jfr pris 7:50/liter drickklar | Ord.pris 36:90 kr.",
+    "ord_pris": "36:90",
+    "jfr_pris": "7:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F672e4b4a1b6ccd191d780c641b203616&w=276&s=39b2c688613022d873b72f9a1a741261"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Läsk",
+    "price": "30:-",
+    "unit": "2 för",
+    "description": "1,5 liter | Flera olika sorter | Coca-Cola, Fanta, Sprite | Max 1 köp/hushåll | Jfr pris 10:00/liter + pant | Ord.pris 22:90 kr.",
+    "ord_pris": "22:90",
+    "jfr_pris": "10:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F95dbbf590a0eb6f34be05bb221f64f77&w=276&s=2e8c62107de7f13c4f9afa8ea0b63bf4"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Kexchoklad",
+    "price": "40:-",
+    "unit": "5 för",
+    "description": "60 g | Cloetta | Jfr pris 133:33/kg | Ord.pris 11:90 kr.",
+    "ord_pris": "11:90",
+    "jfr_pris": "133:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fd469bbc3a7c4892377ae0156288a485a&w=276&s=058fd0a2f3a3ce673023a6920d0dce4d"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Pumpakärnor, Chiafrön",
+    "price": "35:-",
+    "unit": "/st",
+    "description": "300 g | Risenta | Jfr pris 116:67/kg | Ord.pris 42:90-61:90 kr. 30dgr.pris 42:90-61:90 kr.",
+    "ord_pris": "42:90-61:90",
+    "jfr_pris": "116:67",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F67303a7b8e2de4fd9c93a5cc56ca7f1f&w=276&s=9d60fb7f84b448a0759bf35629890465"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Excellence",
+    "price": "65:-",
+    "unit": "2 för",
+    "description": "100 g | Gäller Lindt Excellence | Lindt | Jfr pris 325:00/kg | Ord.pris 42:90 kr.",
+    "ord_pris": "42:90",
+    "jfr_pris": "325:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fd4d77119789264435364c955953bde4f&w=276&s=0b2f90862a71fce6cef32837606016c7"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Tomater på burk",
+    "price": "45:-",
+    "unit": "3 för",
+    "description": "400 g | Finkrossade, körsbärs, hela original | Mutti | Jfr pris 62:50/kg utan spad, 37:50/kg | Ord.pris 20:90-22:90 kr.",
+    "ord_pris": "20:90-22:90",
+    "jfr_pris": "62:50",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F54dcb4d78f27d3f382d813a94f111f7e&w=276&s=44dc24617ef409825df59ee557488360"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Kolsyrat vatten",
+    "price": "19:-",
+    "unit": "2 för",
+    "description": "1,5 liter | Loka | Jfr pris 6:33/liter + pant | Ord.pris 12:90 kr.",
+    "ord_pris": "12:90",
+    "jfr_pris": "6:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F05789d41036e609b336595061ffdd0b3&w=276&s=1c85b33bd2ea8205a3e7dd5b7f598464"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Tortillabröd, Tacosås, Chips",
+    "price": "100:-",
+    "unit": "10 för",
+    "description": "200 g, 320 g, 230 g, 185 g | Gäller tortilla bröd 200 g, 320 g, tacosås och salsasås 230 g samt chips och nacho 185 g. Max 1 köp/hushåll | Santa Maria | Max 1 köp/hushåll | Jfr pris 31:25-54:05/kg | Ord.pris 15:90-25:90 kr.",
+    "ord_pris": "15:90-25:90",
+    "jfr_pris": "31:25-54:05",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fdb837cfd40b25b1f89d948910e0f0c44&w=276&s=6acb0529b002b7fd99081fc854947e0d"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Energidryck",
+    "price": "30:-",
+    "unit": "2 för",
+    "description": "330-355 ml | Nocco | Jfr pris 42:25-45:45/lit exkl pant | Ord.pris 20:90-22:90 kr.",
+    "ord_pris": "20:90-22:90",
+    "jfr_pris": "42:25-45:45",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2F1ab8b57d3cdb67fc5fa85ca803c9d800&w=276&s=512bb85f800da116c57afa243072e794"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Chips, Ostbågar",
+    "price": "50:-",
+    "unit": "2 för",
+    "description": "200-275 g | OLW | Jfr pris 90:91-125:00/kg | Ord.pris 33:90-35:90 kr.",
+    "ord_pris": "33:90-35:90",
+    "jfr_pris": "90:91-125:00",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fbe166ca9adadad264a92b1cbe0932f5d&w=276&s=f165d8bc8bdd8f52f27c11c6eb6af16f"
+  },
+  {
+    "store": "ICA Globen",
+    "name": "Kryddor små glas",
+    "price": "45:-",
+    "unit": "3 för",
+    "description": "3-83 g | Flera olika sorter. Gäller ej ekologisk, salvia och vaniljstång | Santa Maria | Max 1 köp/hushåll | Jfr pris 333:33/kg utan spad, 180:72-5 000:00/kg | Ord.pris 17:90-38:90 kr.",
+    "ord_pris": "17:90-38:90",
+    "jfr_pris": "333:33",
+    "image": "https://image-transformer-api.tjek.com/?u=s3%3A%2F%2Fsgn-prd-assets%2Fuploads%2Fbusiness_images%2F1d1dvA%2Fc17daeb21ea2c41ea237608b2ac75a5f&w=276&s=1d827e6f704e519f75617a985450f152"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Tex-mex (Santa Maria)",
+    "price": "4 för 50:-",
+    "unit": "st",
+    "description": "185-320 g.  Välj mellan nacho/tortillachips, tacosås och tortillabröd original M.",
+    "ord_pris": null,
+    "jfr_pris": "54,35-67,57/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1469923616/155895.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kebab/falafel (Schysst Käk)",
+    "price": "3 för 99:-",
+    "unit": "st",
+    "description": "275 g. Kyld. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "120kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1759061660/cloud/525818.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Gröna druvor  (Sydafrika)",
+    "price": "25:-",
+    "unit": "st",
+    "description": "500 g. Klass 1. Kärnfria. I ask.",
+    "ord_pris": null,
+    "jfr_pris": "50kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1439907017/49160.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Torskryggfilé 3-pack (Royal Greenland)",
+    "price": "99:-",
+    "unit": "st",
+    "description": "3x125 g. Fryst.",
+    "ord_pris": null,
+    "jfr_pris": "264kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1662383206/cloud/258232.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Tacokrydda (Santa Maria)",
+    "price": "2 för 15:-",
+    "unit": "st",
+    "description": "28 g. Original.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1632500631/cloud/234450.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Bacon (Sverige/Scan)",
+    "price": "2 för 25:-",
+    "unit": "st",
+    "description": "125-140 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "89,29-100kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1760709767/cloud/544555.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Matpaj (Felix)",
+    "price": "2 för 55:-",
+    "unit": "st",
+    "description": "210-220 g. Fryst. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1722929515/cloud/376085.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Snacks  (OLW)",
+    "price": "3 för 65:-",
+    "unit": "st",
+    "description": "200-275 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "78,79-108,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1759059092/cloud/525788.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kycklinglårfilé (Sverige/Kronfågel)",
+    "price": "2 för 129:-",
+    "unit": "st",
+    "description": "700 g. Fryst.",
+    "ord_pris": null,
+    "jfr_pris": "92,14/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1760094541/cloud/539116.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Smörgåspålägg (Sverige/Jakobsdals)",
+    "price": "25:-",
+    "unit": "st",
+    "description": "80-100 g. Kylda. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "250-312,50/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1741862045/cloud/453369.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Yoghurt (Yoggi)",
+    "price": "2 för 46:-",
+    "unit": "st",
+    "description": "1000 g. Välj mellan olika sorters original och mini. Gäller ej laktosfri.",
+    "ord_pris": null,
+    "jfr_pris": "23kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1597388279/405157.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Brustabletter  (Berocca Performance)",
+    "price": "2 för 99:-",
+    "unit": "st",
+    "description": "15 st. Välj mellan Berocca Boost och Energy.",
+    "ord_pris": null,
+    "jfr_pris": "3,3/st.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1639267001/cloud/130478.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Parmesanost (Coop)",
+    "price": "45:-",
+    "unit": "st",
+    "description": "150 g.",
+    "ord_pris": null,
+    "jfr_pris": "300kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1731322925/cloud/402120.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Lammrostbiff (Nya Zeeland/Naturkött)",
+    "price": "289:-",
+    "unit": "kg",
+    "description": "Ca 750 g. Kyld. I bit.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1631416809/cloud/163877.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Svenska äpplen (Sverige)",
+    "price": "25:-",
+    "unit": "kg",
+    "description": "Klass 1. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1750241210/cloud/492021.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Klämmis (Hipp)",
+    "price": "9 för 99:-",
+    "unit": "st",
+    "description": "100 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "110kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1624401268/229562.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Mjukt bröd (Fazer)",
+    "price": "25:-",
+    "unit": "st",
+    "description": "420 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "59,52/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1734560404/cloud/418314.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kryddor i småglas (Kockens)",
+    "price": "2 för 39:-",
+    "unit": "st",
+    "description": "8-53 g. Välj mellan olika sorter. Gäller ej ekologiskt eller vaniljstång.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1652350707/cloud/252001.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Blomkål  (Frankrike/Italien)",
+    "price": "25:-",
+    "unit": "kg",
+    "description": "Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1440401585/50169.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Energidryck (Joluca)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "330 ml. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "45,45/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1759039870/cloud/525576.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Läsk 4-pack (Coca-Cola)",
+    "price": "59.9:-",
+    "unit": "st",
+    "description": "4x150 cl.  Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "9,98/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1646735685/cloud/248795.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Strimlad kyckling (Sverige/Guldfågeln)",
+    "price": "79.9:-",
+    "unit": "st",
+    "description": "600 g.  Kyld. Välj mellan marinerad och naturell.",
+    "ord_pris": null,
+    "jfr_pris": "133,17/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1725451855/cloud/383128.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Lasagne (Dafgårds)",
+    "price": "79:-",
+    "unit": "st",
+    "description": "1000-1400 g. Fryst. Välj mellan lyxlasagne och Karins familjelasagne.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1598877290/406267.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Korv (Sverige/Lithells)",
+    "price": "59:-",
+    "unit": "st",
+    "description": "750-900 g. Kyld. Välj mellan varmkorv och wienerkorv.",
+    "ord_pris": null,
+    "jfr_pris": "65,56-78,67/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1764407950/cloud/564130.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Granola (Färsking)",
+    "price": "2 för 75:-",
+    "unit": "st",
+    "description": "375 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "100kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1730874482/cloud/400130.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Blandfärs (EU/John's Selection)",
+    "price": "85:-",
+    "unit": "st",
+    "description": "800 g. Kyld. 50/50 nöt/fläsk. Fetthalt max 20%.",
+    "ord_pris": null,
+    "jfr_pris": "106,25/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1740498630/cloud/445092.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Dessertost (Castello)",
+    "price": "30:-",
+    "unit": "st",
+    "description": "125-150 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "200-240kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1702637060/cloud/311427.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kattmat (Latz)",
+    "price": "2 för 99:-",
+    "unit": "st",
+    "description": "890-1020 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "48,53-55,62/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1729156538/cloud/394718.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kassler (Sverige/Scan)",
+    "price": "99:-",
+    "unit": "kg",
+    "description": "Ca 1000 g. Kyld. I bit.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1742480940/cloud/457132.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Färsk fläskkotlett (Sverige/Coop)",
+    "price": "109:-",
+    "unit": "kg",
+    "description": "Ca 1200 g. Kyld. I bit. Med ben.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1764378035/cloud/563208.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Ekologisk sallad i påse (Land: se förp./Coop)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "65 g. Klass 1. Välj mellan babyspenat, rucola och säsongsmix.",
+    "ord_pris": null,
+    "jfr_pris": "230,77/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1730104836/cloud/397274.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Majskakor  (Friggs)",
+    "price": "2 för 35:-",
+    "unit": "st",
+    "description": "120-130 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "140-145,83/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1646040715/cloud/168923.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Riven ost (Coop)",
+    "price": "2 för 40:-",
+    "unit": "st",
+    "description": "150 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "133,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1705474382/cloud/319392.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Chokladsnacks (Olw)",
+    "price": "2 för 49:-",
+    "unit": "st",
+    "description": "90-150 g. Välj mellan smash och choco crush.",
+    "ord_pris": null,
+    "jfr_pris": "163,33-272,22/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1730986005/cloud/401019.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Havredryck (Coop)",
+    "price": "3 för 40:-",
+    "unit": "st",
+    "description": "1 liter. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "13,33/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1726758135/cloud/387404.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Kakor (Marabou)",
+    "price": "2 för 49:-",
+    "unit": "st",
+    "description": "132-184 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "133,15-185,61/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1624290431/222556.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Glass flerpack (GB Glace)",
+    "price": "2 för 85:-",
+    "unit": "st",
+    "description": "4-12 st. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1715853683/cloud/354972.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Plommontomater (Spanien/Marocko/Coop)",
+    "price": "25:-",
+    "unit": "st",
+    "description": "500 g. Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": "50kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1678363076/cloud/276480.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Pizza Suprema (Dr. Oetker)",
+    "price": "2 för 105:-",
+    "unit": "st",
+    "description": "487-520 g. Fryst. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1724662600/cloud/380853.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Färsk högrev (Irland/John's Selection)",
+    "price": "175:-",
+    "unit": "kg",
+    "description": "Ca 1200 g. Kyld. Av nöt. I bit.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1696841581/cloud/292536.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Gräddfil (Sverige/Coop)",
+    "price": "2 för 25:-",
+    "unit": "st",
+    "description": "300 ml.",
+    "ord_pris": null,
+    "jfr_pris": "41,67/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1726648286/cloud/386564.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Rödbetor i påse (Sverige)",
+    "price": "12:-",
+    "unit": "st",
+    "description": "1 kg. Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1634125714/cloud/236499.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Vegetariskt pålägg (Quorn)",
+    "price": "20:-",
+    "unit": "st",
+    "description": "100 g.",
+    "ord_pris": null,
+    "jfr_pris": "200kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1757944081/cloud/515293.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+    "price": "2 för 55:-",
+    "unit": "st",
+    "description": "150 g. Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": "183,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1760516186/cloud/543345.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Halstabletter (Vicks)",
+    "price": "2 för 32:-",
+    "unit": "st",
+    "description": "72 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "222,22/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1758601895/cloud/520632.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Dubbla Stycksaker (Marabou)",
+    "price": "3 för 25:-",
+    "unit": "st",
+    "description": "37-60 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "138,89-225,23/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1765164784/cloud/574366.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Handskalade räkor/kräftstjärtar (Kosterfiskarn)",
+    "price": "89:-",
+    "unit": "st",
+    "description": "420 g. Kylda. Handskalade.",
+    "ord_pris": null,
+    "jfr_pris": "370,83/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1523673446/289192.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Nötter (OLW)",
+    "price": "2 för 45:-",
+    "unit": "st",
+    "description": "150-300 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "75-150kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1593588377/402636.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Färskost (Philadelphia)",
+    "price": "20:-",
+    "unit": "st",
+    "description": "145-200 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "100-137,93/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1738578139/cloud/431347.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Ätmogen mango  (Brasilien/Peru)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1678273590/cloud/276415.png"
+  },
+  {
+    "store": "Stora Coop Västberga",
+    "name": "Dammsugare (Electrolux)",
+    "price": "1295:-",
+    "unit": "st",
+    "description": "Av 37% återvunnen plast. Max 750W. Sköljbart hygienfilter. Modell Clean 500.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1726576478/cloud/386343.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kebab/falafel (Schysst Käk)",
+    "price": "3 för 99:-",
+    "unit": "st",
+    "description": "275 g. Kyld. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "120kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1759061660/cloud/525818.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kaffe (Coop)",
+    "price": "2 för 109:-",
+    "unit": "st",
+    "description": "450 g.",
+    "ord_pris": null,
+    "jfr_pris": "121,11/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1612355760/419963.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Makaroner (Kungsörnen)",
+    "price": "2 för 22:-",
+    "unit": "st",
+    "description": "750 g. Välj mellan snabbmakaroner och gammeldags idealmakaroner.",
+    "ord_pris": null,
+    "jfr_pris": "14,67/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1765947088/cloud/588997.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Gröna druvor  (Sydafrika)",
+    "price": "25:-",
+    "unit": "st",
+    "description": "500 g. Klass 1. Kärnfria. I ask.",
+    "ord_pris": null,
+    "jfr_pris": "50kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1439907017/49160.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Tex-mex (Santa Maria)",
+    "price": "4 för 50:-",
+    "unit": "st",
+    "description": "185-320 g.  Välj mellan nacho/tortillachips, tacosås och tortillabröd original M.",
+    "ord_pris": null,
+    "jfr_pris": "39,06-67,57/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1469923616/155895.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Svenskt smör (Sverige/Arla)",
+    "price": "55:-",
+    "unit": "st",
+    "description": "500 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "110kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1623365419/131876.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Matpaj (Felix)",
+    "price": "2 för 55:-",
+    "unit": "st",
+    "description": "210-220 g. Fryst. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1722929515/cloud/376085.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Korv (Sverige/Lithells)",
+    "price": "59:-",
+    "unit": "st",
+    "description": "750-900 g. Kyld. Välj mellan varmkorv och wienerkorv.",
+    "ord_pris": null,
+    "jfr_pris": "65,56-78,67/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1764407950/cloud/564130.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kex TUC (LU)",
+    "price": "2 för 20:-",
+    "unit": "st",
+    "description": "100 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "100kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1739969408/cloud/442646.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kylda såser/Dressing (Eriks såser)",
+    "price": "2 för 45:-",
+    "unit": "st",
+    "description": "170-255 ml.  Kyld. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "88,24-132,35/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1741798252/cloud/453006.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Ost (Arla)",
+    "price": "139:-",
+    "unit": "kg",
+    "description": "Ca 500-550 g. Fetthalt 10-17%.Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1671187246/cloud/269640.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Proteinbar (Nick's)",
+    "price": "2 för 35:-",
+    "unit": "st",
+    "description": "35-50 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "350-500kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1747725122/cloud/482139.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Snabbkaffe Original (Nescafè)",
+    "price": "2 för 130:-",
+    "unit": "st",
+    "description": "200 g.",
+    "ord_pris": null,
+    "jfr_pris": "325kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1724405109/cloud/380641.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Vitkål (Sverige/Tyskland)",
+    "price": "12:-",
+    "unit": "kg",
+    "description": "Klass 1. ",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1440061754/49479.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Glass (Häagen-Dazs)",
+    "price": "2 för 99:-",
+    "unit": "st",
+    "description": "460 ml.  Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "107,61/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1647915366/cloud/133475.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Maskindisktabletter (Finish)",
+    "price": "69:-",
+    "unit": "st",
+    "description": "30-42 st. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "1,64-2,30/disk.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1707918474/cloud/327545.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Fruktdryck (Proviva)",
+    "price": "30:-",
+    "unit": "st",
+    "description": "1 liter. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1674493463/cloud/272466.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kebabsås (Schysst Käk)",
+    "price": "2 för 45:-",
+    "unit": "st",
+    "description": "250 ml. Kyld. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "90kr/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1706697242/cloud/323966.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kalkonköttbullar/Kalkonfärs (Sverige/Ingelsta)",
+    "price": "57.9:-",
+    "unit": "st",
+    "description": "400-500 g. Frysta.",
+    "ord_pris": null,
+    "jfr_pris": "115,80-144,75/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1523660812/288326.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Pizza (Grandiosa)",
+    "price": "2 för 85:-",
+    "unit": "st",
+    "description": "575 g. Fryst. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1659000444/cloud/256152.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Kycklingfärs (Coop)",
+    "price": "45:-",
+    "unit": "st",
+    "description": "500 g.  Kyld.",
+    "ord_pris": null,
+    "jfr_pris": "90kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1572944375/385017.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Stor kaviar (Kalles)",
+    "price": "37.9:-",
+    "unit": "st",
+    "description": "250-300 g.  Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "126,33-151,60/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1719984088/cloud/369490.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Biff (Irland/John's Selection)",
+    "price": "59.9:-",
+    "unit": "st",
+    "description": "180 g. Kyld. Med kappa.",
+    "ord_pris": null,
+    "jfr_pris": "332,78/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1677606651/cloud/275171.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Champinjoner i ask (Polen/Litauen/Coop)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "250 g. Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": "60kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1710421662/cloud/336197.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Ekologisk sallad i påse (Land: se förp./Änglamark)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "65 g. Klass 1. Välj mellan babyspenat, rucola och säsongsmix.",
+    "ord_pris": null,
+    "jfr_pris": "230,77/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1730104836/cloud/397274.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Dessertost (Falbygdens Rekommenderar)",
+    "price": "59.9:-",
+    "unit": "st",
+    "description": "150-180 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "332,78-399,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1702645510/cloud/311556.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Bacon (Tulip)",
+    "price": "49:-",
+    "unit": "st",
+    "description": "375-500 g. Kyld. Välj mellan 3-pack och tärnat.",
+    "ord_pris": null,
+    "jfr_pris": "98-130,67/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1636729802/cloud/238985.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Färsk skinkstek (Sverige)",
+    "price": "89:-",
+    "unit": "kg",
+    "description": "Ca 900-1200 g. Kyld. Av fläsk.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1667206977/cloud/264396.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Snacks  (OLW)",
+    "price": "2 för 55:-",
+    "unit": "st",
+    "description": "35-450 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "61,11-785,71/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1759059092/cloud/525788.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Nötter (OLW)",
+    "price": "2 för 49:-",
+    "unit": "st",
+    "description": "150-300 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "81,67-163,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1593588377/402636.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Veganskt protein (Hälsans Kök)",
+    "price": "2 för 99:-",
+    "unit": "st",
+    "description": "440-450 g. Fryst. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "107,61-117,86/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1760255689/cloud/540901.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Läsk (Coca-Cola/Fanta/Sprite)",
+    "price": "5 för 35:-",
+    "unit": "st",
+    "description": "33 cl. Välj mellan olika sorter. Pant tillkommer.",
+    "ord_pris": null,
+    "jfr_pris": "21,21/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1700128864/cloud/302214.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Färskost (Philadelphia)",
+    "price": "22:-",
+    "unit": "st",
+    "description": "145-200 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "110-151,72/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1738578139/cloud/431347.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Torskryggfilé 3-pack (Royal Greenland)",
+    "price": "129:-",
+    "unit": "st",
+    "description": "3x125 g. Fryst.",
+    "ord_pris": null,
+    "jfr_pris": "344kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1662383206/cloud/258232.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Majskakor  (Friggs)",
+    "price": "2 för 39:-",
+    "unit": "st",
+    "description": "120-130 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "150-156kr/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1768923497/cloud/601467.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Blåbär (Chile/Peru)",
+    "price": "49:-",
+    "unit": "st",
+    "description": "300 g. Klass 1.",
+    "ord_pris": null,
+    "jfr_pris": "163,33/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1749626711/cloud/487628.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Chokladkaka (Marabou)",
+    "price": "2 för 50:-",
+    "unit": "st",
+    "description": "160-180 g. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "139,89-156,25/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1758884557/cloud/523795.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Tvättmedel/sköljmedel (A+/Noora)",
+    "price": "2 för 79:-",
+    "unit": "st",
+    "description": "725 g, 880-928 ml. Gäller flytande tvättmedel 880-920 ml, pulvertvättmedel 725 g samt sköljmedel 928 ml.",
+    "ord_pris": null,
+    "jfr_pris": "0,68-2,82/tvätt.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1628670846/cloud/231887.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Fläsklägg  (Sverige/Dalsjöfors)",
+    "price": "49.9:-",
+    "unit": "kg",
+    "description": "Ca 1200 g. Kyld. Rimmad. Med ben.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1704783923/cloud/317183.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Smaksatt creme fraiche (Arla Köket)",
+    "price": "2 för 30:-",
+    "unit": "st",
+    "description": "2 dl. Välj mellan olika sorter.",
+    "ord_pris": null,
+    "jfr_pris": "75kr/liter.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1664279475/cloud/259277.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Lasagne (Rana)",
+    "price": "49.9:-",
+    "unit": "st",
+    "description": "350 g. Kyld. Välj mellan lasagne bolognese och lasagne ricotta & spenat.",
+    "ord_pris": null,
+    "jfr_pris": "142,57/kg.",
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1718952088/cloud/366698.png"
+  },
+  {
+    "store": "Coop Fruängen",
+    "name": "Stekpanna 28 cm (Köksträdgården)",
+    "price": "299:-",
+    "unit": "st",
+    "description": "Av återvunnet stål och PFAS-fri, tålig, keramisk beläggning.",
+    "ord_pris": null,
+    "jfr_pris": null,
+    "image": "https://res.cloudinary.com/coopsverige/image/upload/v1742204322/cloud/454471.png"
   }
 ]

--- a/recipe_matches.json
+++ b/recipe_matches.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-01-30T20:33:42.934984Z",
-  "total_deals": 475,
+  "last_updated": "2026-01-31T22:27:42.124429Z",
+  "total_deals": 619,
   "total_recipes": 737,
   "recipes": [
     {
@@ -339,6 +339,157 @@
       }
     },
     {
+      "name": "Kycklingjärpar i syrlig dillsås och rostade morötter",
+      "url": "https://www.ica.se/recept/kycklingjarpar-i-syrlig-dillsas-och-rostade-morotter-723933/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_181329/cf_259/kycklingjarpar_i_syrlig_dillsas_och_rostade_morotter.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 20,
+      "matched_count": 12,
+      "match_percentage": 60.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 500 g kycklingfärs",
+          "deal_name": "Kycklingfärs",
+          "deal_price": "45:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "90",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "små morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kycklingbuljong",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kruka röd/grön sallad",
+          "deal_name": "Ekologisk sallad i påse",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "230,77",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "svartpeppar",
+        "olja",
+        "ättika",
+        "strösocker",
+        "salt",
+        "vitpeppar",
+        "ask färsk dill"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 11,
+      "nutrition": {
+        "calories": "751 calories",
+        "protein": "35 g",
+        "fat": "38 g",
+        "carbs": "64 g"
+      }
+    },
+    {
       "name": "Chili con verduras",
       "url": "https://www.ica.se/recept/chili-con-verduras-722034/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_160676/cf_259/chili_con_verduras.jpg",
@@ -440,7 +591,7 @@
         {
           "ingredient": "baguette",
           "deal_name": "Baguette",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -450,7 +601,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -460,11 +611,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -534,12 +685,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -857,13 +1008,13 @@
         },
         {
           "ingredient": "majs",
-          "deal_name": "Majs-, Riskakor",
-          "deal_price": "35:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90-26:90",
-          "jfr_pris": "140:00-145:83",
-          "match_score": 0.9
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 1.0
         },
         {
           "ingredient": "knippe rädisor",
@@ -888,7 +1039,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -994,12 +1145,12 @@
         },
         {
           "ingredient": "skivat bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
+          "deal_name": "SKIVAT BACON 5-PACK",
+          "deal_price": "58.90:-",
+          "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "117,80",
           "match_score": 0.9
         },
         {
@@ -1055,11 +1206,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -1068,7 +1219,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -1174,11 +1325,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -1338,18 +1489,18 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -1372,148 +1523,6 @@
         "protein": "40 g",
         "fat": "39 g",
         "carbs": "58 g"
-      }
-    },
-    {
-      "name": "Kycklingjärpar i syrlig dillsås och rostade morötter",
-      "url": "https://www.ica.se/recept/kycklingjarpar-i-syrlig-dillsas-och-rostade-morotter-723933/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_181329/cf_259/kycklingjarpar_i_syrlig_dillsas_och_rostade_morotter.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 20,
-      "matched_count": 11,
-      "match_percentage": 55.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ca 500 g kycklingfärs",
-          "deal_name": "Kycklingfärs",
-          "deal_price": "45:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "90",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "små morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "kycklingbuljong",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "kruka röd/grön sallad",
-          "deal_name": "Ekologisk sallad i påse",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "230,77",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "salt",
-        "svartpeppar",
-        "olja",
-        "ättika",
-        "strösocker",
-        "majsstärkelse",
-        "salt",
-        "vitpeppar",
-        "ask färsk dill"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 11,
-      "nutrition": {
-        "calories": "751 calories",
-        "protein": "35 g",
-        "fat": "38 g",
-        "carbs": "64 g"
       }
     },
     {
@@ -1587,12 +1596,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -1662,6 +1671,151 @@
       }
     },
     {
+      "name": "Taco med majsfritters och pico de gallo",
+      "url": "https://www.ica.se/recept/taco-med-majsfritters-och-pico-de-gallo-725965/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203609/cf_259/taco_med_majsfritters_och_pico_de_gallo.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 23,
+      "matched_count": 11,
+      "match_percentage": 47.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "medelstor silverlök eller gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 1/2 röd eller grön chilifrukt",
+          "deal_name": "Stor grön kiwi",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "53,33",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "avokado",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "havrebaserad fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "tacosås eller srirachasås",
+          "deal_name": "Tortillabröd, Tacochips, Tacosås",
+          "deal_price": "100:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "54,05",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "mjuka tortillabröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "bakpulver",
+        "kikärtsmjöl",
+        "ca 1 tsk cayennepeppar",
+        "havregrädde",
+        "salt",
+        "svartpeppar",
+        "kruka grovhackad koriander",
+        "kokta svarta bönor",
+        "lime",
+        "riven vitlöksklyfta",
+        "salt",
+        "peppar"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 47,
+      "nutrition": {
+        "calories": "764 calories",
+        "protein": "20 g",
+        "fat": "40 g",
+        "carbs": "76 g"
+      }
+    },
+    {
       "name": "Zucchiniplättar med bönsallad och couscous",
       "url": "https://www.ica.se/recept/zucchiniplattar-med-bonsallad-och-couscous-728188/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232631/cf_259/zucchiniplattar_med_bonsallad_och_couscous_.jpg",
@@ -1702,22 +1856,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -1763,7 +1917,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -1772,12 +1926,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -1850,22 +2004,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -1911,7 +2065,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -1920,12 +2074,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -2136,12 +2290,12 @@
         },
         {
           "ingredient": "grovriven västerbottensost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -2213,6 +2367,137 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Pannbiff i gräddig sås med svamp",
+      "url": "https://www.ica.se/recept/pannbiff-i-graddig-sas-med-svamp-728466/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234029/cf_259/pannbiff_i_graddig_sas_med_svamp.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 10,
+      "match_percentage": 55.6,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "köttbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "vatten",
+        "salt",
+        "peppar",
+        "torkad timjan",
+        "olja",
+        "vatten",
+        "japansk soja",
+        "färsk gräslök"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 16,
+      "nutrition": {
+        "calories": "610 calories",
+        "protein": "34 g",
+        "fat": "32 g",
+        "carbs": "43 g"
       }
     },
     {
@@ -2296,13 +2581,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "finskurna salladslökar",
@@ -2711,12 +2996,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -2814,11 +3099,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -2847,7 +3132,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -2873,6 +3158,139 @@
         "protein": "42 g",
         "fat": "46 g",
         "carbs": "51 g"
+      }
+    },
+    {
+      "name": "Kikärtstacos med avokado och paprikasallad",
+      "url": "https://www.ica.se/recept/kikartstacos-med-avokado-och-paprikasallad-727934/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_230312/cf_259/kikartstacos_med_avokado_och_paprikasallad.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 20,
+      "matched_count": 10,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "gul paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "taco kryddmix",
+          "deal_name": "Pulled beef taco",
+          "deal_price": "62.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "170,00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "påse tortillachips",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyfta",
+        "spiskummin",
+        "salt",
+        "peppar",
+        "krispsallad eller romansallad",
+        "lime",
+        "kokta kikärtor",
+        "olja",
+        "tomatpuré",
+        "vatten"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 13,
+      "nutrition": {
+        "calories": "954 calories",
+        "protein": "27 g",
+        "fat": "38 g",
+        "carbs": "115 g"
       }
     },
     {
@@ -3111,11 +3529,11 @@
         {
           "ingredient": "grillost eller halloumi",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -3225,11 +3643,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -3279,368 +3697,106 @@
       }
     },
     {
-      "name": "Chili con linser med jalapeños",
-      "url": "https://www.ica.se/recept/chili-con-linser-med-jalapenos-728334/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233486/cf_259/chili_con_linser_med_jalapeños_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 23,
+      "name": "Smörrebröd med panerad rödspätta",
+      "url": "https://www.ica.se/recept/smorrebrod-med-panerad-rodspatta-727680/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_224897/cf_259/panerad_rodspatta_pa_ragbrod.jpg",
+      "category": "Huvudrätt,Middag,Brunch",
+      "total_ingredients": 22,
       "matched_count": 10,
-      "match_percentage": 43.5,
+      "match_percentage": 45.5,
       "matched_ingredients": [
         {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gul paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "krossade tomater",
-          "deal_name": "Krossade tomater",
-          "deal_price": "30:-",
+          "ingredient": "rotselleri",
+          "deal_name": "Rotselleri, Kålrot",
+          "deal_price": "15:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "37,50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "grönsaksbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
+          "jfr_pris": "15",
           "match_score": 0.9
         },
         {
-          "ingredient": "torkade röda linser",
-          "deal_name": "Röda kärnfria druvor i ask",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "salladslök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
+          "ingredient": "äggula",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "plommontomater",
-          "deal_name": "Plommontomater",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "40",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse tortillachips",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "matyoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "vitlöksklyftor",
-        "olivolja",
-        "spiskummin",
-        "tomatpuré",
-        "vatten",
-        "japansk soja",
-        "jalapeños",
-        "kokta kidneybönor",
-        "salt",
-        "peppar",
-        "lime",
-        "färsk koriander",
-        "jalapeños"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 36,
-      "nutrition": {
-        "calories": "588 calories",
-        "protein": "23 g",
-        "fat": "24 g",
-        "carbs": "64 g"
-      }
-    },
-    {
-      "name": "Chili con linser med jalapeños",
-      "url": "https://www.ica.se/recept/chili-con-linser-med-jalapenos-728334/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233486/cf_259/chili_con_linser_med_jalapeños_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 23,
-      "matched_count": 10,
-      "match_percentage": 43.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gul paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "krossade tomater",
-          "deal_name": "Krossade tomater",
-          "deal_price": "30:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "37,50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "grönsaksbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "torkade röda linser",
-          "deal_name": "Röda kärnfria druvor i ask",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "salladslök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "plommontomater",
-          "deal_name": "Plommontomater",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "40",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse tortillachips",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "matyoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "vitlöksklyftor",
-        "olivolja",
-        "spiskummin",
-        "tomatpuré",
-        "vatten",
-        "japansk soja",
-        "jalapeños",
-        "kokta kidneybönor",
-        "salt",
-        "peppar",
-        "lime",
-        "färsk koriander",
-        "jalapeños"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 36,
-      "nutrition": {
-        "calories": "588 calories",
-        "protein": "23 g",
-        "fat": "24 g",
-        "carbs": "64 g"
-      }
-    },
-    {
-      "name": "Overnight oats med fyra sorters topping",
-      "url": "https://www.ica.se/recept/overnight-oats-med-fyra-sorters-topping-725226/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247980/cf_259/overnight_oats_med_fyra_sorters_topping.jpg",
-      "category": "Frukost,Brunch",
-      "total_ingredients": 27,
-      "matched_count": 10,
-      "match_percentage": 37.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "chiafrön",
-          "deal_name": "Pumpakärnor, Chiafrön",
-          "deal_price": "35:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "47:90-68:90",
-          "jfr_pris": "116:67",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kvarg",
-          "deal_name": "Mild kvarg/Grekisk Yoghurt",
-          "deal_price": "35:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "48:95-52:00",
-          "jfr_pris": "35:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "blåbär",
-          "deal_name": "Blåbär",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "163,33",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "färska bär",
-          "deal_name": "FÄRSKA KRYDDOR 15-25G",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "660",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "skal från 1/2 lime",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "tärnat äpple",
-          "deal_name": "Svenska äpplen",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "31:90-36:90",
           "jfr_pris": null,
           "match_score": 0.85
         },
         {
-          "ingredient": "flytande honung",
-          "deal_name": "Flytande tvättmedel",
-          "deal_price": "119:-",
+          "ingredient": "neutral rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "4 för",
-          "ord_pris": "47:90-51:90",
-          "jfr_pris": "1:29-1:35",
-          "match_score": 0.75
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
         },
         {
-          "ingredient": "mogen mosad banan",
-          "deal_name": "Mogen avokado 3-pack",
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "uppvispade ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
           "deal_price": "25:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "44:95",
-          "jfr_pris": "75:76",
-          "match_score": 0.75
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
         },
         {
-          "ingredient": "jordnötssmör",
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "skivor rågbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rostade skalade hasselnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ask smörgåskrasse",
           "deal_name": "Smör",
           "deal_price": "55:-",
           "deal_store": "ICA Nära",
@@ -3648,46 +3804,577 @@
           "ord_pris": "78:00",
           "jfr_pris": "110:00",
           "match_score": 0.9
-        },
+        }
+      ],
+      "unmatched_ingredients": [
+        "silverlök",
+        "ättiksprit",
+        "strösocker",
+        "vatten",
+        "salt",
+        "kruka dill",
+        "dijonsenap",
+        "vitvinsvinäger",
+        "finrivet citronskal",
+        "salt",
+        "rödspättafilé",
+        "panko"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.9,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Chili con linser med jalapeños",
+      "url": "https://www.ica.se/recept/chili-con-linser-med-jalapenos-728334/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233486/cf_259/chili_con_linser_med_jalapeños_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 23,
+      "matched_count": 10,
+      "match_percentage": 43.5,
+      "matched_ingredients": [
         {
-          "ingredient": "färska blåbär",
-          "deal_name": "Blåbär",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "163,33",
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "gul paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "krossade tomater",
+          "deal_name": "Krossade tomater",
+          "deal_price": "30:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "37,50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "grönsaksbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "torkade röda linser",
+          "deal_name": "Röda kärnfria druvor i ask",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "salladslök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "plommontomater",
+          "deal_name": "Plommontomater",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "40",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse tortillachips",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "matyoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "havregryn",
-        "havre-, nöt- eller kokosdryck",
-        "ca 1/4 krm stött kardemumma",
-        "ca 1/2 krm vaniljpulver",
-        "agavesirap",
-        "flagad mandel eller frön",
-        "hallon",
-        "kokossocker",
-        "exotisk frukt",
-        "kokosflakes",
-        "ev kanel",
-        "ca 1/4 krm stött kardemumma",
-        "malen kanel",
-        "ca 1/2 krm vaniljpulver",
-        "hackad mandel eller pumpakärnor",
-        "salta jordnötter",
-        "skivad banan"
+        "vitlöksklyftor",
+        "olivolja",
+        "spiskummin",
+        "tomatpuré",
+        "vatten",
+        "japansk soja",
+        "jalapeños",
+        "kokta kidneybönor",
+        "salt",
+        "peppar",
+        "lime",
+        "färsk koriander",
+        "jalapeños"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 36,
+      "nutrition": {
+        "calories": "588 calories",
+        "protein": "23 g",
+        "fat": "24 g",
+        "carbs": "64 g"
+      }
+    },
+    {
+      "name": "Chili con linser med jalapeños",
+      "url": "https://www.ica.se/recept/chili-con-linser-med-jalapenos-728334/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233486/cf_259/chili_con_linser_med_jalapeños_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 23,
+      "matched_count": 10,
+      "match_percentage": 43.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "gul paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "krossade tomater",
+          "deal_name": "Krossade tomater",
+          "deal_price": "30:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "37,50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "grönsaksbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "torkade röda linser",
+          "deal_name": "Röda kärnfria druvor i ask",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "salladslök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "plommontomater",
+          "deal_name": "Plommontomater",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "40",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse tortillachips",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "matyoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyftor",
+        "olivolja",
+        "spiskummin",
+        "tomatpuré",
+        "vatten",
+        "japansk soja",
+        "jalapeños",
+        "kokta kidneybönor",
+        "salt",
+        "peppar",
+        "lime",
+        "färsk koriander",
+        "jalapeños"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 36,
+      "nutrition": {
+        "calories": "588 calories",
+        "protein": "23 g",
+        "fat": "24 g",
+        "carbs": "64 g"
+      }
+    },
+    {
+      "name": "Krämig pasta med svamp och grönsaker",
+      "url": "https://www.ica.se/recept/kramig-pasta-med-svamp-och-gronsaker-726663/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213414/cf_259/kramig_pasta_med_svamp_och_gronsaker.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 24,
+      "matched_count": 10,
+      "match_percentage": 41.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "palsternacka",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kycklingbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spaghetti",
+          "deal_name": "SPAGHETTI",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "19,90",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "skogschampinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färskpressad citronjuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "finriven parmesan",
+          "deal_name": "Västerbottensost®",
+          "deal_price": "89:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "135:00",
+          "jfr_pris": "197:78",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "torkad rosmarin",
+        "torkad timjan",
+        "salt",
+        "svartpeppar",
+        "vatten",
+        "japansk soja",
+        "svartvinbärsgelé",
+        "peppar",
+        "salt",
+        "-  2 vitlöksklyftor",
+        "olivolja",
+        "finrivet citronskal",
+        "ev chiliflakes"
       ],
       "time": "PT90M",
-      "servings": "1",
-      "rating": 4.6,
-      "reviews": 164,
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 21,
       "nutrition": {
-        "calories": "233 calories",
-        "protein": "11 g",
-        "fat": "6 g",
-        "carbs": "32 g"
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Krämig pasta med svamp och grönsaker",
+      "url": "https://www.ica.se/recept/kramig-pasta-med-svamp-och-gronsaker-726663/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213414/cf_259/kramig_pasta_med_svamp_och_gronsaker.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 24,
+      "matched_count": 10,
+      "match_percentage": 41.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "palsternacka",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kycklingbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spaghetti",
+          "deal_name": "SPAGHETTI",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "19,90",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "skogschampinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färskpressad citronjuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "finriven parmesan",
+          "deal_name": "Västerbottensost®",
+          "deal_price": "89:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "135:00",
+          "jfr_pris": "197:78",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "torkad rosmarin",
+        "torkad timjan",
+        "salt",
+        "svartpeppar",
+        "vatten",
+        "japansk soja",
+        "svartvinbärsgelé",
+        "peppar",
+        "salt",
+        "-  2 vitlöksklyftor",
+        "olivolja",
+        "finrivet citronskal",
+        "ev chiliflakes"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 21,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -3721,12 +4408,12 @@
         },
         {
           "ingredient": "riven gruyère eller parmesanost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Parmesanost",
+          "deal_price": "45:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "300",
           "match_score": 0.9
         },
         {
@@ -3830,6 +4517,357 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Tacolåda",
+      "url": "https://www.ica.se/recept/tacolada-740480/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/yl3nviwvvug9afcbogxn.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 9,
+      "match_percentage": 81.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "kycklingfärs eller hushållsfärs",
+          "deal_name": "Kycklingfärs",
+          "deal_price": "45:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "90",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "taco kryddmix",
+          "deal_name": "Pulled beef taco",
+          "deal_price": "62.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "170,00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "passerade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche paprika & chili",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd , small",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "sallad",
+          "deal_name": "Socker- och salladsärtor i påse",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "29:95-34:95",
+          "jfr_pris": "133:33",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "matlådor"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 38,
+      "nutrition": {
+        "calories": "538 calories",
+        "protein": "39 g",
+        "fat": "21 g",
+        "carbs": "47 g"
+      }
+    },
+    {
+      "name": "Tex mex-soppa med quesadillas",
+      "url": "https://www.ica.se/recept/tex-mex-soppa-med-quesadillas-725035/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195455/cf_259/tex_mex-soppa_med_quesadillas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 9,
+      "match_percentage": 64.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 500 g nötfärs eller hushållsfärs",
+          "deal_name": "Umamifärs",
+          "deal_price": null,
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "54:90",
+          "jfr_pris": "79:80",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "köttbuljong",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "pastasås chili",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "plommontomater",
+          "deal_name": "Plommontomater",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "40",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "små tortillabröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "spiskummin",
+        "tomatpuré"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 84,
+      "nutrition": {
+        "calories": "733 calories",
+        "protein": "51 g",
+        "fat": "35 g",
+        "carbs": "50 g"
+      }
+    },
+    {
+      "name": "Tex mex-soppa med quesadillas",
+      "url": "https://www.ica.se/recept/tex-mex-soppa-med-quesadillas-725035/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195455/cf_259/tex_mex-soppa_med_quesadillas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 9,
+      "match_percentage": 64.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 500 g nötfärs eller hushållsfärs",
+          "deal_name": "Umamifärs",
+          "deal_price": null,
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "54:90",
+          "jfr_pris": "79:80",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "köttbuljong",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "pastasås chili",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "plommontomater",
+          "deal_name": "Plommontomater",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "40",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "små tortillabröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "spiskummin",
+        "tomatpuré"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 84,
+      "nutrition": {
+        "calories": "733 calories",
+        "protein": "51 g",
+        "fat": "35 g",
+        "carbs": "50 g"
       }
     },
     {
@@ -4031,12 +5069,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -4066,6 +5104,125 @@
         "protein": "47 g",
         "fat": "52 g",
         "carbs": "60 g"
+      }
+    },
+    {
+      "name": "Fläskfilégryta med champinjoner",
+      "url": "https://www.ica.se/recept/flaskfilegryta-med-champinjoner-724256/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_186632/cf_259/flaskfilégryta_med_champinjoner.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 9,
+      "match_percentage": 60.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "fläskfilé eller fläskytterfilé",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "hönsbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kokt ris eller  potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "sallad",
+          "deal_name": "Socker- och salladsärtor i påse",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "29:95-34:95",
+          "jfr_pris": "133:33",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "peppar",
+        "tomatpuré",
+        "mjölk",
+        "japansk soja",
+        "dijonsenap"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 1636,
+      "nutrition": {
+        "calories": "739 calories",
+        "protein": "34 g",
+        "fat": "48 g",
+        "carbs": "41 g"
       }
     },
     {
@@ -4149,22 +5306,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "parmesan eller annan lagrad hårdost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -4198,13 +5355,13 @@
       "matched_ingredients": [
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "gul lök",
@@ -4249,11 +5406,11 @@
         {
           "ingredient": "grillad kycklingbröstfilé",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -4387,22 +5544,22 @@
         },
         {
           "ingredient": "rostade vita sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
           "ingredient": "ostronsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -4517,11 +5674,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -4636,7 +5793,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -4755,7 +5912,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -4875,7 +6032,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -4935,11 +6092,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -5065,11 +6222,11 @@
         {
           "ingredient": "prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -5095,7 +6252,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -5141,6 +6298,127 @@
         "protein": "22 g",
         "fat": "55 g",
         "carbs": "79 g"
+      }
+    },
+    {
+      "name": "Krämig pasta med fläskfilé",
+      "url": "https://www.ica.se/recept/kramig-pasta-med-flaskfile-730323/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/srdgxz2mwkeoj2rnmvz2.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 17,
+      "matched_count": 9,
+      "match_percentage": 52.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 500 g fläskfilé",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "färska champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "strimlade soltorkade tomater i olja",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hönsbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "portioner tagliatelle",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven parmesan",
+          "deal_name": "Parmesanost",
+          "deal_price": "45:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "300",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyftor",
+        "salt",
+        "svartpeppar",
+        "vatten",
+        "vatten",
+        "citron",
+        "babyspenat",
+        "kruka basilika"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 55,
+      "nutrition": {
+        "calories": "733 calories",
+        "protein": "40 g",
+        "fat": "35 g",
+        "carbs": "60 g"
       }
     },
     {
@@ -5205,11 +6483,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -5262,6 +6540,127 @@
         "protein": "10 g",
         "fat": "27 g",
         "carbs": "18 g"
+      }
+    },
+    {
+      "name": "Fisknuggets med rostad potatis, broccoli och citronsås",
+      "url": "https://www.ica.se/recept/fisknuggets-med-rostad-potatis-broccoli-och-citronsas-729716/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246638/cf_259/fisknuggets_med_rostad_potatis__broccoli_och_citronsas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 17,
+      "matched_count": 9,
+      "match_percentage": 52.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "-  2 msk färskpressad citronjuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "finrivet citronskal",
+        "vitlöksklyfta",
+        "salt",
+        "mandelspån",
+        "torskfilé",
+        "salt",
+        "panko"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 18,
+      "nutrition": {
+        "calories": "845 calories",
+        "protein": "36 g",
+        "fat": "35 g",
+        "carbs": "89 g"
       }
     },
     {
@@ -5325,22 +6724,22 @@
         },
         {
           "ingredient": "fryst majs",
-          "deal_name": "Majs-, Riskakor",
-          "deal_price": "35:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90-26:90",
-          "jfr_pris": "140:00-145:83",
-          "match_score": 0.9
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 1.0
         },
         {
           "ingredient": "riven prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -5416,18 +6815,18 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -5437,11 +6836,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -5504,6 +6903,127 @@
         "protein": "33 g",
         "fat": "33 g",
         "carbs": "71 g"
+      }
+    },
+    {
+      "name": "Svampsoppa",
+      "url": "https://www.ica.se/recept/svampsoppa-721120/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_164662/cf_259/svampsoppa.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 17,
+      "matched_count": 9,
+      "match_percentage": 52.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "frysta skivade champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "grönsaksbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "bröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rostade solrosfrön och  pumpakärnor",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "turkisk yoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "fryst svampmix",
+        "vitt matlagningsvin",
+        "vatten",
+        "japansk soja",
+        "timjan",
+        "oregano",
+        "salt",
+        "svartpeppar"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 18,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -5698,12 +7218,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -5809,13 +7329,13 @@
         },
         {
           "ingredient": "frysta tinade majskorn",
-          "deal_name": "Frysta Thaiboxar",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "3 för",
-          "ord_pris": "45:90",
-          "jfr_pris": "84:76-98:89",
-          "match_score": 0.75
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
           "ingredient": "hel färdiggrillad kyckling eller helstekt kyckling i ugn",
@@ -5839,12 +7359,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -5871,9 +7391,9 @@
       }
     },
     {
-      "name": "Pannbiff i gräddig sås med svamp",
-      "url": "https://www.ica.se/recept/pannbiff-i-graddig-sas-med-svamp-728466/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234029/cf_259/pannbiff_i_graddig_sas_med_svamp.jpg",
+      "name": "Pannbiff med gräddig löksås",
+      "url": "https://www.ica.se/recept/pannbiff-med-graddig-loksas-726027/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210381/cf_259/pannbiff_med_graddig_loksas.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 18,
       "matched_count": 9,
@@ -5900,13 +7420,13 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
+          "ingredient": "nötfärs",
+          "deal_name": "Umamifärs",
+          "deal_price": null,
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "54:90",
+          "jfr_pris": "79:80",
           "match_score": 0.85
         },
         {
@@ -5920,34 +7440,24 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "smör",
+          "ingredient": "smör eller olja",
           "deal_name": "Smör",
           "deal_price": "55:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
           "ord_pris": "78:00",
           "jfr_pris": "110:00",
-          "match_score": 1.0
+          "match_score": 0.9
         },
         {
-          "ingredient": "champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 1.0
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
           "ingredient": "matlagningsgrädde",
@@ -5968,28 +7478,160 @@
           "ord_pris": "22:95",
           "jfr_pris": "2:50",
           "match_score": 0.9
+        },
+        {
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "vatten",
+        "mjölk",
+        "dijonsenap",
         "salt",
         "peppar",
-        "torkad timjan",
         "olja",
-        "vatten",
-        "majsstärkelse",
+        "färsk eller fryst lök",
+        "mjölk",
         "japansk soja",
-        "färsk gräslök"
+        "ask färsk persilja"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 16,
+      "rating": 4.6,
+      "reviews": 27,
       "nutrition": {
-        "calories": "610 calories",
-        "protein": "34 g",
-        "fat": "32 g",
-        "carbs": "43 g"
+        "calories": "734 calories",
+        "protein": "43 g",
+        "fat": "37 g",
+        "carbs": "54 g"
+      }
+    },
+    {
+      "name": "Wokad biff med bambuskott",
+      "url": "https://www.ica.se/recept/wokad-biff-med-bambuskott-726364/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_209525/cf_259/wokad_biff_med_bambuskott.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 9,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "jasminris eller äggnudlar",
+          "deal_name": "NUDLAR",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "213,98",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ca 450 g ryggbiff",
+          "deal_name": "Färsk biff",
+          "deal_price": "59.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "332,78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ostronsås",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "konc oxfond",
+          "deal_name": "Fond",
+          "deal_price": "60:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "41:90",
+          "jfr_pris": "7:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "finskurna salladslökar",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyfta",
+        "japansk soja",
+        "strösocker",
+        "crema di balsamico",
+        "vatten",
+        "sesamolja",
+        "salt",
+        "svartpeppar",
+        "skivade bambuskott"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 85,
+      "nutrition": {
+        "calories": "498 calories",
+        "protein": "33 g",
+        "fat": "12 g",
+        "carbs": "62 g"
       }
     },
     {
@@ -6115,6 +7757,129 @@
       }
     },
     {
+      "name": "Korean fried chicken burger",
+      "url": "https://www.ica.se/recept/korean-fried-chicken-burger-750743/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/axkcb3driai5ouvc0tle.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 19,
+      "matched_count": 9,
+      "match_percentage": 47.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "stor morot",
+          "deal_name": "Stor grön kiwi",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "53,33",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gochujang chilipasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kallt vatten",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vetemjöl",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kallt vatten",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kycklinglårfiléer",
+          "deal_name": "Kycklinglårfilé",
+          "deal_price": "79.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,97",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hamburgerbröd",
+          "deal_name": "Hamburgerbröd",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "50",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "risvinäger",
+        "strösocker",
+        "vitlöksklyftor",
+        "japansk soja",
+        "risvinäger",
+        "farinsocker",
+        "bakpulver",
+        "salt",
+        "ca 10 dl frityrolja",
+        "majonnäs"
+      ],
+      "time": "PT60M",
+      "servings": "4",
+      "rating": 4.9,
+      "reviews": 7,
+      "nutrition": {
+        "calories": "712 calories",
+        "protein": "24 g",
+        "fat": "32 g",
+        "carbs": "81 g"
+      }
+    },
+    {
       "name": "Marry me butter beans med citronricotta",
       "url": "https://www.ica.se/recept/marry-me-butter-beans-med-citronricotta-750424/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/g1trn68sapm5pdddkzrn.jpg",
@@ -6196,11 +7961,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -6298,18 +8063,18 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -6578,7 +8343,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -6608,14 +8373,188 @@
       }
     },
     {
-      "name": "Kikärtstacos med avokado och paprikasallad",
-      "url": "https://www.ica.se/recept/kikartstacos-med-avokado-och-paprikasallad-727934/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_230312/cf_259/kikartstacos_med_avokado_och_paprikasallad.jpg",
+      "name": "Gratinerade nachos med mango- och avokadosalsa",
+      "url": "https://www.ica.se/recept/gratinerade-nachos-med-mango-och-avokadosalsa-726399/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213798/cf_259/gratinerade_nachos_med_mango-_och_avokadosalsa.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 20,
       "matched_count": 9,
       "match_percentage": 45.0,
       "matched_ingredients": [
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "pastasås basilika",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven prästost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "avokado",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fryst mango",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "kokta svarta bönor",
+        "vitlöksklyfta",
+        "olja",
+        "sambal oelek",
+        "salt",
+        "nachochips",
+        "lime",
+        "salt",
+        "peppar",
+        "lime",
+        "olja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 16,
+      "nutrition": {
+        "calories": "817 calories",
+        "protein": "21 g",
+        "fat": "43 g",
+        "carbs": "79 g"
+      }
+    },
+    {
+      "name": "Bön- och majsburgare med avokadokräm",
+      "url": "https://www.ica.se/recept/bon-och-majsburgare-med-avokadokram-722220/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_161133/cf_259/bon-_och_majsburgare_med_avokadokram.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 20,
+      "matched_count": 9,
+      "match_percentage": 45.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
         {
           "ingredient": "avokador",
           "deal_name": "Avokado",
@@ -6627,37 +8566,17 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gul paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
-          "match_score": 0.9
+          "match_score": 1.0
         },
         {
-          "ingredient": "gul lök",
+          "ingredient": "rödlök",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -6667,68 +8586,38 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "taco kryddmix",
-          "deal_name": "Pulled beef taco",
-          "deal_price": "62.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "170,00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "påse tortillachips",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "vitlöksklyfta",
+        "olja",
+        "kokta kidneybönor",
+        "solroskärnor",
         "spiskummin",
         "salt",
         "peppar",
-        "krispsallad eller romansallad",
-        "lime",
-        "kokta kikärtor",
-        "majskorn",
         "olja",
-        "tomatpuré",
-        "vatten"
+        "cayennepeppar",
+        "vitlöksklyfta",
+        "lime",
+        "kruka krispsallad"
       ],
       "time": "PT45M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 13,
+      "reviews": 71,
       "nutrition": {
-        "calories": "954 calories",
-        "protein": "27 g",
-        "fat": "38 g",
-        "carbs": "115 g"
+        "calories": "687 calories",
+        "protein": "20 g",
+        "fat": "33 g",
+        "carbs": "70 g"
       }
     },
     {
@@ -6857,6 +8746,131 @@
       }
     },
     {
+      "name": "Kycklingtacos med rostad majs och chipotlemajonnäs",
+      "url": "https://www.ica.se/recept/kycklingtacos-med-rostad-majs-och-chipotlemajonnas-724779/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_190189/cf_259/kycklingtacos_med_rostad_majs_och_chipotlemajonnas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 21,
+      "matched_count": 9,
+      "match_percentage": 42.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 500 g kycklinglårfilé",
+          "deal_name": "Kycklinglårfilé",
+          "deal_price": "79.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,97",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "-  2 tsk chipotlepaste",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rökt paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "chipotlepaste",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smulad fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "picklad rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja till stekning",
+        "mald spiskummin",
+        "finhackade vitlöksklyftor",
+        "mald koriander",
+        "salt",
+        "nymalen svartpeppar",
+        "salt",
+        "saft från 1 lime",
+        "majonnäs",
+        "salt",
+        "hackad färsk koriander",
+        "limeklyftor"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 25,
+      "nutrition": {
+        "calories": "591 calories",
+        "protein": "37 g",
+        "fat": "29 g",
+        "carbs": "44 g"
+      }
+    },
+    {
       "name": "Balsamicobräserad fläskfilé med rödkålsrisotto",
       "url": "https://www.ica.se/recept/balsamicobraserad-flaskfile-med-rodkalsrisotto-714778/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_63553/cf_259/balsamicobraserad_flaskfilé_med_rodkalsrisotto.jpg",
@@ -6979,132 +8993,6 @@
         "protein": "45 g",
         "fat": "26.3 g",
         "carbs": "61.1 g"
-      }
-    },
-    {
-      "name": "Smörrebröd med panerad rödspätta",
-      "url": "https://www.ica.se/recept/smorrebrod-med-panerad-rodspatta-727680/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_224897/cf_259/panerad_rodspatta_pa_ragbrod.jpg",
-      "category": "Huvudrätt,Middag,Brunch",
-      "total_ingredients": 22,
-      "matched_count": 9,
-      "match_percentage": 40.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "rotselleri",
-          "deal_name": "Rotselleri, Kålrot",
-          "deal_price": "15:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "15",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "äggula",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "neutral rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "uppvispade ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "skivor rågbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rostade skalade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ask smörgåskrasse",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "silverlök",
-        "ättiksprit",
-        "strösocker",
-        "vatten",
-        "salt",
-        "kruka dill",
-        "dijonsenap",
-        "vitvinsvinäger",
-        "finrivet citronskal",
-        "salt",
-        "rödspättafilé",
-        "majsstärkelse",
-        "panko"
-      ],
-      "time": "PT90M",
-      "servings": "4",
-      "rating": 4.9,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -7255,11 +9143,11 @@
         {
           "ingredient": "bostongurka",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -7451,11 +9339,11 @@
         {
           "ingredient": "getost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -7614,133 +9502,6 @@
       }
     },
     {
-      "name": "Taco med majsfritters och pico de gallo",
-      "url": "https://www.ica.se/recept/taco-med-majsfritters-och-pico-de-gallo-725965/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203609/cf_259/taco_med_majsfritters_och_pico_de_gallo.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 23,
-      "matched_count": 9,
-      "match_percentage": 39.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "medelstor silverlök eller gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ca 1/2 röd eller grön chilifrukt",
-          "deal_name": "Stor grön kiwi",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "53,33",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "avokado",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "havrebaserad fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "tacosås eller srirachasås",
-          "deal_name": "Tortillabröd, Tacochips, Tacosås",
-          "deal_price": "100:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "54,05",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "mjuka tortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "majskorn",
-        "majsstärkelse",
-        "bakpulver",
-        "kikärtsmjöl",
-        "ca 1 tsk cayennepeppar",
-        "havregrädde",
-        "salt",
-        "svartpeppar",
-        "kruka grovhackad koriander",
-        "kokta svarta bönor",
-        "lime",
-        "riven vitlöksklyfta",
-        "salt",
-        "peppar"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 47,
-      "nutrition": {
-        "calories": "764 calories",
-        "protein": "20 g",
-        "fat": "40 g",
-        "carbs": "76 g"
-      }
-    },
-    {
       "name": "Sallad med sötpotatis, kyckling och chilidressing",
       "url": "https://www.ica.se/recept/sallad-med-sotpotatis-kyckling-och-chilidressing-723562/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_238416/cf_259/sallad_med_sotpotatis__kyckling_och_chilidressing.jpg",
@@ -7825,18 +9586,18 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
         {
           "ingredient": "rostade nötter eller frön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -7869,144 +9630,157 @@
       }
     },
     {
-      "name": "Krämig pasta med svamp och grönsaker",
-      "url": "https://www.ica.se/recept/kramig-pasta-med-svamp-och-gronsaker-726663/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213414/cf_259/kramig_pasta_med_svamp_och_gronsaker.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 24,
+      "name": "Overnight oats med fyra sorters topping",
+      "url": "https://www.ica.se/recept/overnight-oats-med-fyra-sorters-topping-725226/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247980/cf_259/overnight_oats_med_fyra_sorters_topping.jpg",
+      "category": "Frukost,Brunch",
+      "total_ingredients": 27,
       "matched_count": 9,
-      "match_percentage": 37.5,
+      "match_percentage": 33.3,
       "matched_ingredients": [
         {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
+          "ingredient": "chiafrön",
+          "deal_name": "Pumpakärnor, Chiafrön",
+          "deal_price": "35:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "47:90-68:90",
+          "jfr_pris": "116:67",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kvarg",
+          "deal_name": "Mild kvarg/Grekisk Yoghurt",
+          "deal_price": "35:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "48:95-52:00",
+          "jfr_pris": "35:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "blåbär",
+          "deal_name": "Blåbär",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "163,33",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "färska bär",
+          "deal_name": "FÄRSKA KRYDDOR 15-25G",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
+          "jfr_pris": "660",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "skal från 1/2 lime",
+          "deal_name": "Räkor med skal 90/120",
+          "deal_price": "79:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "62:90",
+          "jfr_pris": "98:75",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "tärnat äpple",
+          "deal_name": "Svenska äpplen",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/kg",
+          "ord_pris": "31:90-36:90",
+          "jfr_pris": null,
           "match_score": 0.85
         },
         {
-          "ingredient": "morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "ingredient": "flytande honung",
+          "deal_name": "Flytande tvättmedel",
+          "deal_price": "119:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "4 för",
+          "ord_pris": "47:90-51:90",
+          "jfr_pris": "1:29-1:35",
+          "match_score": 0.75
         },
         {
-          "ingredient": "palsternacka",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kycklingbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
+          "ingredient": "jordnötssmör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
           "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
           "match_score": 0.9
         },
         {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "spaghetti",
-          "deal_name": "SPAGHETTI",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "19,90",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "skogschampinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
+          "ingredient": "färska blåbär",
+          "deal_name": "Blåbär",
+          "deal_price": "49:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "60",
+          "jfr_pris": "163,33",
           "match_score": 0.9
-        },
-        {
-          "ingredient": "färskpressad citronjuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "finriven parmesan",
-          "deal_name": "Västerbottensost®",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "135:00",
-          "jfr_pris": "197:78",
-          "match_score": 0.85
         }
       ],
       "unmatched_ingredients": [
-        "olivolja",
-        "torkad rosmarin",
-        "torkad timjan",
-        "salt",
-        "svartpeppar",
-        "vatten",
-        "japansk soja",
-        "svartvinbärsgelé",
-        "majsstärkelse",
-        "peppar",
-        "salt",
-        "-  2 vitlöksklyftor",
-        "olivolja",
-        "finrivet citronskal",
-        "ev chiliflakes"
+        "havregryn",
+        "havre-, nöt- eller kokosdryck",
+        "ca 1/4 krm stött kardemumma",
+        "ca 1/2 krm vaniljpulver",
+        "agavesirap",
+        "flagad mandel eller frön",
+        "hallon",
+        "kokossocker",
+        "exotisk frukt",
+        "kokosflakes",
+        "ev kanel",
+        "ca 1/4 krm stött kardemumma",
+        "malen kanel",
+        "ca 1/2 krm vaniljpulver",
+        "hackad mandel eller pumpakärnor",
+        "mogen mosad banan",
+        "salta jordnötter",
+        "skivad banan"
       ],
       "time": "PT90M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 21,
+      "servings": "1",
+      "rating": 4.6,
+      "reviews": 164,
       "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
+        "calories": "233 calories",
+        "protein": "11 g",
+        "fat": "6 g",
+        "carbs": "32 g"
       }
     },
     {
-      "name": "Krämig pasta med svamp och grönsaker",
-      "url": "https://www.ica.se/recept/kramig-pasta-med-svamp-och-gronsaker-726663/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213414/cf_259/kramig_pasta_med_svamp_och_gronsaker.jpg",
+      "name": "Pasta med bacon och ostssallad",
+      "url": "https://www.ica.se/recept/pasta-med-bacon-och-ostssallad-722370/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_162823/cf_259/pasta_med_bacon_och_ostssallad.jpg",
       "category": "Huvudrätt,Middag",
-      "total_ingredients": 24,
-      "matched_count": 9,
-      "match_percentage": 37.5,
+      "total_ingredients": 10,
+      "matched_count": 8,
+      "match_percentage": 80.0,
       "matched_ingredients": [
         {
-          "ingredient": "gul lök",
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rödlök",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -8016,112 +9790,79 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
+          "ingredient": "klippt bacon",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "palsternacka",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kycklingbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
+          "ingredient": "matlagningsgrädde",
           "deal_name": "Vispgrädde",
           "deal_price": "29:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "spaghetti",
-          "deal_name": "SPAGHETTI",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "19,90",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "skogschampinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färskpressad citronjuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "finriven parmesan",
-          "deal_name": "Västerbottensost®",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "135:00",
-          "jfr_pris": "197:78",
           "match_score": 0.85
+        },
+        {
+          "ingredient": "salladsost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "olivolja",
-        "torkad rosmarin",
-        "torkad timjan",
-        "salt",
-        "svartpeppar",
-        "vatten",
-        "japansk soja",
-        "svartvinbärsgelé",
-        "majsstärkelse",
-        "peppar",
-        "salt",
-        "-  2 vitlöksklyftor",
-        "olivolja",
-        "finrivet citronskal",
-        "ev chiliflakes"
+        "mjölk",
+        "peppar"
       ],
-      "time": "PT90M",
+      "time": "PT30M",
       "servings": "4",
-      "rating": 4.8,
-      "reviews": 21,
+      "rating": 4.5,
+      "reviews": 36,
       "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
+        "calories": "772 calories",
+        "protein": "29 g",
+        "fat": "43 g",
+        "carbs": "64 g"
       }
     },
     {
@@ -8166,7 +9907,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -8206,7 +9947,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -8230,109 +9971,109 @@
       }
     },
     {
-      "name": "Tacolåda",
-      "url": "https://www.ica.se/recept/tacolada-740480/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/yl3nviwvvug9afcbogxn.jpg",
+      "name": "Vego tacos med tortillabröd",
+      "url": "https://www.ica.se/recept/vego-tacos-med-tortillabrod-728661/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241258/cf_259/vego_tacos_med_tortillabrod.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 8,
       "match_percentage": 72.7,
       "matched_ingredients": [
         {
-          "ingredient": "kycklingfärs eller hushållsfärs",
-          "deal_name": "Kycklingfärs",
-          "deal_price": "45:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "90",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "taco kryddmix",
-          "deal_name": "Pulled beef taco",
-          "deal_price": "62.90:-",
+          "ingredient": "torr taco vegofärs",
+          "deal_name": "Färsk Vego",
+          "deal_price": "60:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "170,00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "passerade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "100",
           "match_score": 0.9
         },
         {
-          "ingredient": "crème fraiche paprika & chili",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
+          "ingredient": "stor rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
           "deal_store": "ICA Supermarket",
           "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
           "match_score": 0.9
         },
         {
-          "ingredient": "tortillabröd , small",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
           "match_score": 0.9
         },
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
-          "ingredient": "sallad",
-          "deal_name": "Socker- och salladsärtor i påse",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
-          "jfr_pris": "133:33",
+          "ingredient": "tacosås",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
           "match_score": 0.9
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
         }
       ],
       "unmatched_ingredients": [
+        "isbergssalladshuvud",
         "olja",
-        "majskorn",
-        "matlådor"
+        "ca 100 g tortillachips"
       ],
-      "time": "PT45M",
+      "time": "PT30M",
       "servings": "4",
-      "rating": 4.6,
-      "reviews": 38,
+      "rating": 4.7,
+      "reviews": 69,
       "nutrition": {
-        "calories": "538 calories",
-        "protein": "39 g",
-        "fat": "21 g",
-        "carbs": "47 g"
+        "calories": "567 calories",
+        "protein": "38 g",
+        "fat": "39 g",
+        "carbs": "84 g"
       }
     },
     {
@@ -8397,7 +10138,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -8420,7 +10161,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -8502,12 +10243,12 @@
         },
         {
           "ingredient": "rostade kokoschips",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -8569,8 +10310,18 @@
         },
         {
           "ingredient": "kycklingbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "färdig ostsås",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -8578,23 +10329,13 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "färdig ostsås",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -8653,6 +10394,113 @@
         "protein": "30 g",
         "fat": "30 g",
         "carbs": "66 g"
+      }
+    },
+    {
+      "name": "Champinjonsoppa",
+      "url": "https://www.ica.se/recept/champinjonsoppa-715952/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_69453/cf_259/champinjonsoppa.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 8,
+      "match_percentage": 66.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "konc grönsaksfond",
+          "deal_name": "Fond",
+          "deal_price": "60:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "41:90",
+          "jfr_pris": "7:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kallt vatten",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "torkad timjan",
+        "mjölk",
+        "salt",
+        "peppar"
+      ],
+      "time": "PT60M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 411,
+      "nutrition": {
+        "calories": "675 calories",
+        "protein": "13 g",
+        "fat": "61 g",
+        "carbs": "20 g"
       }
     },
     {
@@ -8717,11 +10565,11 @@
         {
           "ingredient": "ostronsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -8736,12 +10584,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -8760,6 +10608,114 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Nachotallrik",
+      "url": "https://www.ica.se/recept/nachotallrik-729736/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247937/cf_259/nachotallrik.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 8,
+      "match_percentage": 61.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "nötfärs eller blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "mild taco kryddmix",
+          "deal_name": "Mild kvarg/Grekisk Yoghurt",
+          "deal_price": "35:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "48:95-52:00",
+          "jfr_pris": "35:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "sallad",
+          "deal_name": "Socker- och salladsärtor i påse",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "29:95-34:95",
+          "jfr_pris": "133:33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tacosås",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "vatten",
+        "nachochips",
+        "-  1 dl inlagd jalapeño",
+        "tärnad gurka"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 22,
+      "nutrition": {
+        "calories": "806 calories",
+        "protein": "40 g",
+        "fat": "43 g",
+        "carbs": "61 g"
       }
     },
     {
@@ -8952,11 +10908,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -9010,7 +10966,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -9030,7 +10986,7 @@
         {
           "ingredient": "färska hamburgare",
           "deal_name": "FÄRSKA HAMBURGARE",
-          "deal_price": "Medlemspris",
+          "deal_price": "44.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -9087,6 +11043,114 @@
       }
     },
     {
+      "name": "Kalkongryta med paprika och basilika",
+      "url": "https://www.ica.se/recept/kalkongryta-med-paprika-och-basilika-728276/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232673/cf_259/kalkongryta_med_paprika_och_basilika_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 8,
+      "match_percentage": 61.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "bananschalottenlökar",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "kalkonbröstfilé",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "påse haricots verts",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "mjölk",
+        "salt",
+        "peppar",
+        "färsk basilika"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 7,
+      "nutrition": {
+        "calories": "597 calories",
+        "protein": "35 g",
+        "fat": "30 g",
+        "carbs": "42 g"
+      }
+    },
+    {
       "name": "Chicken nuggets med currydip och klyftisar",
       "url": "https://www.ica.se/recept/chicken-nuggets-med-currydip-och-klyftisar-724532/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192577/cf_259/chicken_nuggets_med_currydip_och_klyftisar.jpg",
@@ -9108,7 +11172,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -9168,7 +11232,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -9279,7 +11343,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -9373,12 +11437,12 @@
         },
         {
           "ingredient": "rostat surdegsbröd",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -9409,224 +11473,6 @@
         "protein": "16 g",
         "fat": "17 g",
         "carbs": "8.8 g"
-      }
-    },
-    {
-      "name": "Tex mex-soppa med quesadillas",
-      "url": "https://www.ica.se/recept/tex-mex-soppa-med-quesadillas-725035/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195455/cf_259/tex_mex-soppa_med_quesadillas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 8,
-      "match_percentage": 57.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ca 500 g nötfärs eller hushållsfärs",
-          "deal_name": "Umamifärs",
-          "deal_price": null,
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "54:90",
-          "jfr_pris": "79:80",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "köttbuljong",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "pastasås chili",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "plommontomater",
-          "deal_name": "Plommontomater",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "40",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "små tortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "spiskummin",
-        "tomatpuré",
-        "majskorn"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 84,
-      "nutrition": {
-        "calories": "733 calories",
-        "protein": "51 g",
-        "fat": "35 g",
-        "carbs": "50 g"
-      }
-    },
-    {
-      "name": "Tex mex-soppa med quesadillas",
-      "url": "https://www.ica.se/recept/tex-mex-soppa-med-quesadillas-725035/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195455/cf_259/tex_mex-soppa_med_quesadillas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 8,
-      "match_percentage": 57.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ca 500 g nötfärs eller hushållsfärs",
-          "deal_name": "Umamifärs",
-          "deal_price": null,
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "54:90",
-          "jfr_pris": "79:80",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "köttbuljong",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "pastasås chili",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "plommontomater",
-          "deal_name": "Plommontomater",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "40",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "små tortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "spiskummin",
-        "tomatpuré",
-        "majskorn"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 84,
-      "nutrition": {
-        "calories": "733 calories",
-        "protein": "51 g",
-        "fat": "35 g",
-        "carbs": "50 g"
       }
     },
     {
@@ -10066,6 +11912,115 @@
       }
     },
     {
+      "name": "Mörrumsgryta",
+      "url": "https://www.ica.se/recept/morrumsgryta-317139/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_39754/cf_259/morrumsgryta.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 8,
+      "match_percentage": 57.1,
+      "matched_ingredients": [
+        {
+          "ingredient": "laxfilé",
+          "deal_name": "Färsk laxfilé",
+          "deal_price": "149:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "149",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "fiskbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "- msk majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "knippe dill",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "portioner kokt potatis eller ris",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "morot",
+        "citron",
+        "vatten",
+        "vitvinsvinäger",
+        "salt",
+        "vitpeppar"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 85,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
       "name": "Kycklingtacos med grillad sparris & kryddig gräddfil",
       "url": "https://www.ica.se/recept/kycklingtacos-med-grillad-sparris-kryddig-graddfil-725806/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_201494/cf_259/kycklingtacos_med_grillad_sparris___kryddig_graddfil.jpg",
@@ -10107,7 +12062,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -10172,6 +12127,115 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Krämig laxgryta med räkor och dill",
+      "url": "https://www.ica.se/recept/kramig-laxgryta-med-rakor-och-dill-721466/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_153199/cf_259/kramig_laxgryta_med_rakor_och_dill.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 8,
+      "match_percentage": 57.1,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "purjolök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "räkor i lake",
+          "deal_name": "Räkor med skal 90/120",
+          "deal_price": "79:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "62:90",
+          "jfr_pris": "98:75",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spad från räkorna",
+          "deal_name": "Räkor med skal 90/120",
+          "deal_price": "79:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "62:90",
+          "jfr_pris": "98:75",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "vitt matlagningsvin",
+        "portionsbitar lax",
+        "salt",
+        "cayennepeppar",
+        "ask färsk dill"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 85,
+      "nutrition": {
+        "calories": "625 calories",
+        "protein": "30.1 g",
+        "fat": "33.2 g",
+        "carbs": "48 g"
       }
     },
     {
@@ -10246,7 +12310,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -10395,36 +12459,136 @@
       }
     },
     {
-      "name": "Fläskfilégryta med champinjoner",
-      "url": "https://www.ica.se/recept/flaskfilegryta-med-champinjoner-724256/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_186632/cf_259/flaskfilégryta_med_champinjoner.jpg",
+      "name": "Kyckling med potatis- och majssallad och äppelsås",
+      "url": "https://www.ica.se/recept/kyckling-med-potatis-och-majssallad-och-appelsas-729151/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_240428/cf_259/kyckling_med_potatis-_och_majssallad_och_appelsas.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 15,
       "matched_count": 8,
       "match_percentage": 53.3,
       "matched_ingredients": [
         {
-          "ingredient": "fläskfilé eller fläskytterfilé",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
-          "ingredient": "gul lök",
+          "ingredient": "salladslök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "äpplen",
+          "deal_name": "Svenska äpplen",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/kg",
+          "ord_pris": "31:90-36:90",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grekisk yoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "honung",
+          "deal_name": "Blomsterhonung",
+          "deal_price": "55:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "55",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "bbq-marinerade kycklingfiléer",
+          "deal_name": "Färsk kycklingfilé",
+          "deal_price": "119:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/kg",
+          "ord_pris": "179:00",
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "citron",
+        "olivolja",
+        "salt",
+        "svartpeppar",
+        "babyspenat",
+        "salt",
+        "svartpeppar"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 12,
+      "nutrition": {
+        "calories": "832 calories",
+        "protein": "48 g",
+        "fat": "46 g",
+        "carbs": "53 g"
+      }
+    },
+    {
+      "name": "Färspanna med potatis och paprika",
+      "url": "https://www.ica.se/recept/farspanna-med-potatis-och-paprika-728643/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_237147/cf_259/farspanna_med_potatis_och_paprika.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -10434,17 +12598,37 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 1.0
+          "ingredient": "nötfärs",
+          "deal_name": "Umamifärs",
+          "deal_price": null,
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "54:90",
+          "jfr_pris": "79:80",
+          "match_score": 0.85
         },
         {
-          "ingredient": "hönsbuljongtärning",
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "köttbuljongtärning",
           "deal_name": "Buljong",
           "deal_price": "30:-",
           "deal_store": "ICA Nära",
@@ -10454,117 +12638,567 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "vispgrädde",
+          "ingredient": "gul paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "morot",
+        "olja",
+        "salt",
+        "peppar",
+        "torkad oregano",
+        "tomatpuré",
+        "mjölk"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "561 calories",
+        "protein": "34 g",
+        "fat": "25 g",
+        "carbs": "46 g"
+      }
+    },
+    {
+      "name": "Rostade gulbetor med krispiga oststicks",
+      "url": "https://www.ica.se/recept/rostade-gulbetor-med-krispiga-oststicks-728312/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232759/cf_259/rostade_gulbetor_med_krispiga_oststicks_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "honung",
+          "deal_name": "Blomsterhonung",
+          "deal_price": "55:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "55",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grillost eller halloumi",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vetemjöl",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matyoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "gulbetor",
+        "olivolja",
+        "salt",
+        "peppar",
+        "solroskärnor",
+        "olja",
+        "mâchesallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 20,
+      "nutrition": {
+        "calories": "810 calories",
+        "protein": "33 g",
+        "fat": "44 g",
+        "carbs": "65 g"
+      }
+    },
+    {
+      "name": "Rostade gulbetor med krispiga oststicks",
+      "url": "https://www.ica.se/recept/rostade-gulbetor-med-krispiga-oststicks-728312/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232759/cf_259/rostade_gulbetor_med_krispiga_oststicks_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "honung",
+          "deal_name": "Blomsterhonung",
+          "deal_price": "55:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "55",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grillost eller halloumi",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vetemjöl",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matyoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "gulbetor",
+        "olivolja",
+        "salt",
+        "peppar",
+        "solroskärnor",
+        "olja",
+        "mâchesallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 20,
+      "nutrition": {
+        "calories": "810 calories",
+        "protein": "33 g",
+        "fat": "44 g",
+        "carbs": "65 g"
+      }
+    },
+    {
+      "name": "Het pasta med torrsaltat bacon och majs",
+      "url": "https://www.ica.se/recept/het-pasta-med-torrsaltat-bacon-och-majs-723235/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_174176/cf_259/het_pasta_med_torrsaltat_bacon_och_majs.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "torrsaltat bacon",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "soltorkade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matlagningsgrädde",
           "deal_name": "Vispgrädde",
           "deal_price": "29:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
           "match_score": 1.0
         },
         {
-          "ingredient": "kokt ris eller  potatis",
-          "deal_name": "Sötpotatis",
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "röd peppar",
+        "vitlöksklyfta",
+        "mjölk",
+        "salt",
+        "peppar",
+        "färsk gräslök eller persilja"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 28,
+      "nutrition": {
+        "calories": "738 calories",
+        "protein": "27 g",
+        "fat": "36 g",
+        "carbs": "72 g"
+      }
+    },
+    {
+      "name": "Enchiladas med avokadosalsa",
+      "url": "https://www.ica.se/recept/enchiladas-med-avokadosalsa-726385/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213237/cf_259/enchiladas_med_avokadosalsa.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "pastasås vitlök",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven prästost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ask plommontomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
           "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "spiskummin",
+        "kokta kidneybönor",
+        "salt",
+        "peppar",
+        "lime",
+        "olivolja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 26,
+      "nutrition": {
+        "calories": "906 calories",
+        "protein": "44 g",
+        "fat": "44 g",
+        "carbs": "77 g"
+      }
+    },
+    {
+      "name": "Enkel vegansk tacopaj",
+      "url": "https://www.ica.se/recept/enkel-vegansk-tacopaj-725958/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203487/cf_259/enkel_vegansk_tacopaj.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 8,
+      "match_percentage": 53.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "kylskåpskallt mjölkfritt margarin",
+          "deal_name": "LAKTOSFRI MJÖLK",
+          "deal_price": "42:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
           "jfr_pris": null,
           "match_score": 0.85
         },
         {
-          "ingredient": "sallad",
-          "deal_name": "Socker- och salladsärtor i påse",
-          "deal_price": "20:-",
+          "ingredient": "vetemjöl",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "iskallt vatten",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gula lökar",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "växtbaserad crème fraiche med paprika och chili",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
-          "jfr_pris": "133:33",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "salt",
-        "peppar",
-        "tomatpuré",
-        "mjölk",
-        "japansk soja",
-        "dijonsenap",
-        "majsstärkelse"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 1636,
-      "nutrition": {
-        "calories": "739 calories",
-        "protein": "34 g",
-        "fat": "48 g",
-        "carbs": "41 g"
-      }
-    },
-    {
-      "name": "Rostade gulbetor med krispiga oststicks",
-      "url": "https://www.ica.se/recept/rostade-gulbetor-med-krispiga-oststicks-728312/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232759/cf_259/rostade_gulbetor_med_krispiga_oststicks_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 8,
-      "match_percentage": 53.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
           "match_score": 0.85
         },
         {
-          "ingredient": "honung",
-          "deal_name": "Blomsterhonung",
-          "deal_price": "55:-",
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "55",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "grillost eller halloumi",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vetemjöl",
+          "ingredient": "ask cocktailtomater",
           "deal_name": "TE",
           "deal_price": "39:-",
           "deal_store": "ICA Maxi",
@@ -10572,156 +13206,26 @@
           "ord_pris": null,
           "jfr_pris": null,
           "match_score": 0.9
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matyoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "gulbetor",
-        "olivolja",
-        "salt",
-        "peppar",
-        "solroskärnor",
+        "vitlöksklyftor",
         "olja",
-        "mâchesallad"
+        "sojafärs",
+        "mald spiskummin",
+        "mald  koriander",
+        "salt",
+        "svartpeppar"
       ],
-      "time": "PT45M",
+      "time": "PT90M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 20,
+      "reviews": 33,
       "nutrition": {
-        "calories": "810 calories",
-        "protein": "33 g",
-        "fat": "44 g",
-        "carbs": "65 g"
-      }
-    },
-    {
-      "name": "Rostade gulbetor med krispiga oststicks",
-      "url": "https://www.ica.se/recept/rostade-gulbetor-med-krispiga-oststicks-728312/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232759/cf_259/rostade_gulbetor_med_krispiga_oststicks_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 8,
-      "match_percentage": 53.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "honung",
-          "deal_name": "Blomsterhonung",
-          "deal_price": "55:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "55",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "grillost eller halloumi",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vetemjöl",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matyoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "gulbetor",
-        "olivolja",
-        "salt",
-        "peppar",
-        "solroskärnor",
-        "olja",
-        "mâchesallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 20,
-      "nutrition": {
-        "calories": "810 calories",
-        "protein": "33 g",
-        "fat": "44 g",
-        "carbs": "65 g"
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -10736,11 +13240,11 @@
         {
           "ingredient": "ostronskivling",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -10785,12 +13289,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -10806,7 +13310,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -10998,7 +13502,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -11018,11 +13522,11 @@
         {
           "ingredient": "kycklingbröstfiléer",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -11109,7 +13613,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -11129,11 +13633,11 @@
         {
           "ingredient": "kycklingbröstfiléer",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -11229,12 +13733,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -11402,22 +13906,22 @@
         {
           "ingredient": "skivor vitt rostbröd",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
+          "deal_price": "40:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
-          "match_score": 1.0
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "bacon",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "friterad lök",
@@ -11513,7 +14017,7 @@
         {
           "ingredient": "baguette",
           "deal_name": "Baguette",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -11613,26 +14117,26 @@
       }
     },
     {
-      "name": "Krämig pasta med fläskfilé",
-      "url": "https://www.ica.se/recept/kramig-pasta-med-flaskfile-730323/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/srdgxz2mwkeoj2rnmvz2.jpg",
+      "name": "Svamppasta med timjanrostad rotselleri",
+      "url": "https://www.ica.se/recept/svamppasta-med-timjanrostad-rotselleri-728442/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233991/cf_259/svamppasta_med_timjanrostad_rotselleri.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 17,
       "matched_count": 8,
       "match_percentage": 47.1,
       "matched_ingredients": [
         {
-          "ingredient": "ca 500 g fläskfilé",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
+          "ingredient": "rotselleri",
+          "deal_name": "Rotselleri, Kålrot",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "15",
           "match_score": 0.9
         },
         {
-          "ingredient": "gul lök",
+          "ingredient": "rödlökar",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -11642,33 +14146,13 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "färska champinjoner",
+          "ingredient": "kastanjechampinjoner",
           "deal_name": "Champinjoner",
           "deal_price": "30:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": "60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "strimlade soltorkade tomater i olja",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "hönsbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
           "match_score": 0.9
         },
         {
@@ -11682,7 +14166,37 @@
           "match_score": 1.0
         },
         {
-          "ingredient": "portioner tagliatelle",
+          "ingredient": "grönsaksbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färsk pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "romanticatomater",
           "deal_name": "TE",
           "deal_price": "39:-",
           "deal_store": "ICA Maxi",
@@ -11690,150 +14204,28 @@
           "ord_pris": null,
           "jfr_pris": null,
           "match_score": 0.9
-        },
-        {
-          "ingredient": "riven parmesan",
-          "deal_name": "Parmesanost",
-          "deal_price": "45:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "300",
-          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "vitlöksklyftor",
+        "olivolja",
+        "kruka timjan",
         "salt",
-        "svartpeppar",
+        "peppar",
+        "olivolja",
+        "vitlöksklyfta",
+        "vitt matlagningsvin",
         "vatten",
-        "majsstärkelse",
-        "vatten",
-        "citron",
-        "babyspenat",
-        "kruka basilika"
+        "mâchesallad"
       ],
-      "time": "PT45M",
+      "time": "PT30M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 55,
+      "reviews": 13,
       "nutrition": {
-        "calories": "733 calories",
-        "protein": "40 g",
-        "fat": "35 g",
-        "carbs": "60 g"
-      }
-    },
-    {
-      "name": "Fisknuggets med rostad potatis, broccoli och citronsås",
-      "url": "https://www.ica.se/recept/fisknuggets-med-rostad-potatis-broccoli-och-citronsas-729716/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246638/cf_259/fisknuggets_med_rostad_potatis__broccoli_och_citronsas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 17,
-      "matched_count": 8,
-      "match_percentage": 47.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "-  2 msk färskpressad citronjuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "salt",
-        "finrivet citronskal",
-        "vitlöksklyfta",
-        "salt",
-        "mandelspån",
-        "torskfilé",
-        "salt",
-        "majsstärkelse",
-        "panko"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 18,
-      "nutrition": {
-        "calories": "845 calories",
-        "protein": "36 g",
-        "fat": "35 g",
-        "carbs": "89 g"
+        "calories": "490 calories",
+        "protein": "12 g",
+        "fat": "26 g",
+        "carbs": "47 g"
       }
     },
     {
@@ -12101,22 +14493,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "hackade, rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -12170,118 +14562,6 @@
         "protein": "44 g",
         "fat": "54 g",
         "carbs": "79 g"
-      }
-    },
-    {
-      "name": "Svampsoppa",
-      "url": "https://www.ica.se/recept/svampsoppa-721120/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_164662/cf_259/svampsoppa.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 17,
-      "matched_count": 8,
-      "match_percentage": 47.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "frysta skivade champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "grönsaksbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "bröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rostade solrosfrön och  pumpakärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "turkisk yoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "fryst svampmix",
-        "vitt matlagningsvin",
-        "vatten",
-        "japansk soja",
-        "timjan",
-        "oregano",
-        "majsstärkelse",
-        "salt",
-        "svartpeppar"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 18,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -12359,7 +14639,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -12511,43 +14791,23 @@
       }
     },
     {
-      "name": "Pannbiff med gräddig löksås",
-      "url": "https://www.ica.se/recept/pannbiff-med-graddig-loksas-726027/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210381/cf_259/pannbiff_med_graddig_loksas.jpg",
-      "category": "Huvudrätt,Middag",
+      "name": "Cheddarpaj med kryddstekt kyckling",
+      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
+      "category": "Huvudrätt,Middag,Brunch",
       "total_ingredients": 18,
       "matched_count": 8,
       "match_percentage": 44.4,
       "matched_ingredients": [
         {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "riven cheddarost",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "59,52",
+          "jfr_pris": "139,90",
           "match_score": 0.9
-        },
-        {
-          "ingredient": "nötfärs",
-          "deal_name": "Umamifärs",
-          "deal_price": null,
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "54:90",
-          "jfr_pris": "79:80",
-          "match_score": 0.85
         },
         {
           "ingredient": "ägg",
@@ -12560,110 +14820,57 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "smör eller olja",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matlagningsgrädde",
+          "ingredient": "vispgrädde",
           "deal_name": "Vispgrädde",
           "deal_price": "29:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
           "match_score": 0.85
         },
         {
-          "ingredient": "köttbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölk",
-        "dijonsenap",
-        "salt",
-        "peppar",
-        "olja",
-        "färsk eller fryst lök",
-        "mjölk",
-        "majsstärkelse",
-        "japansk soja",
-        "ask färsk persilja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 27,
-      "nutrition": {
-        "calories": "734 calories",
-        "protein": "43 g",
-        "fat": "37 g",
-        "carbs": "54 g"
-      }
-    },
-    {
-      "name": "Korean fried chicken burger",
-      "url": "https://www.ica.se/recept/korean-fried-chicken-burger-750743/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/axkcb3driai5ouvc0tle.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 19,
-      "matched_count": 8,
-      "match_percentage": 42.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "stor morot",
-          "deal_name": "Stor grön kiwi",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
+          "ingredient": "ca 600 g minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "53,33",
+          "jfr_pris": "133,17/kg.",
           "match_score": 0.75
         },
         {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "jfr_pris": "99:00",
+          "match_score": 0.85
         },
         {
-          "ingredient": "gochujang chilipasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kallt vatten",
+          "ingredient": "körsbärstomater",
           "deal_name": "TE",
           "deal_price": "39:-",
           "deal_store": "ICA Maxi",
@@ -12671,70 +14878,255 @@
           "ord_pris": null,
           "jfr_pris": null,
           "match_score": 0.9
-        },
-        {
-          "ingredient": "vetemjöl",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kallt vatten",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kycklinglårfiléer",
-          "deal_name": "Kycklinglårfilé",
-          "deal_price": "79.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,97",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "hamburgerbröd",
-          "deal_name": "Hamburgerbröd",
-          "deal_price": "15:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "50",
-          "match_score": 1.0
         }
       ],
       "unmatched_ingredients": [
-        "risvinäger",
-        "strösocker",
-        "vitlöksklyftor",
-        "japansk soja",
-        "risvinäger",
-        "farinsocker",
-        "majsstärkelse",
-        "bakpulver",
+        "färsk pajdeg",
+        "mjölk",
         "salt",
-        "ca 10 dl frityrolja",
-        "majonnäs"
+        "svartpeppar",
+        "oregano",
+        "rosmarin",
+        "salt",
+        "peppar",
+        "citron",
+        "krispsallad"
       ],
-      "time": "PT60M",
-      "servings": "4",
-      "rating": 4.9,
-      "reviews": 7,
+      "time": "PT45M",
+      "servings": "8 bufféportioner",
+      "rating": 4.8,
+      "reviews": 27,
       "nutrition": {
-        "calories": "712 calories",
-        "protein": "24 g",
-        "fat": "32 g",
-        "carbs": "81 g"
+        "calories": "493 calories",
+        "protein": "30 g",
+        "fat": "34 g",
+        "carbs": "17 g"
+      }
+    },
+    {
+      "name": "Cheddarpaj med kryddstekt kyckling",
+      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
+      "category": "Huvudrätt,Middag,Brunch",
+      "total_ingredients": 18,
+      "matched_count": 8,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "riven cheddarost",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "körsbärstomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "färsk pajdeg",
+        "mjölk",
+        "salt",
+        "svartpeppar",
+        "oregano",
+        "rosmarin",
+        "salt",
+        "peppar",
+        "citron",
+        "krispsallad"
+      ],
+      "time": "PT45M",
+      "servings": "8 bufféportioner",
+      "rating": 4.8,
+      "reviews": 27,
+      "nutrition": {
+        "calories": "493 calories",
+        "protein": "30 g",
+        "fat": "34 g",
+        "carbs": "17 g"
+      }
+    },
+    {
+      "name": "Cheddarpaj med kryddstekt kyckling",
+      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
+      "category": "Huvudrätt,Middag,Brunch",
+      "total_ingredients": 18,
+      "matched_count": 8,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "riven cheddarost",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "körsbärstomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "färsk pajdeg",
+        "mjölk",
+        "salt",
+        "svartpeppar",
+        "oregano",
+        "rosmarin",
+        "salt",
+        "peppar",
+        "citron",
+        "krispsallad"
+      ],
+      "time": "PT45M",
+      "servings": "8 bufféportioner",
+      "rating": 4.8,
+      "reviews": 27,
+      "nutrition": {
+        "calories": "493 calories",
+        "protein": "30 g",
+        "fat": "34 g",
+        "carbs": "17 g"
       }
     },
     {
@@ -12799,7 +15191,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -12902,12 +15294,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -13225,11 +15617,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -13245,7 +15637,7 @@
         {
           "ingredient": "riven mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -13369,22 +15761,22 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
           "ingredient": "majs",
-          "deal_name": "Majs-, Riskakor",
-          "deal_price": "35:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90-26:90",
-          "jfr_pris": "140:00-145:83",
-          "match_score": 0.9
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 1.0
         },
         {
           "ingredient": "tomater",
@@ -13473,11 +15865,11 @@
         {
           "ingredient": "ostronsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -13618,11 +16010,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -13649,236 +16041,6 @@
         "protein": "31 g",
         "fat": "47 g",
         "carbs": "43 g"
-      }
-    },
-    {
-      "name": "Gratinerade nachos med mango- och avokadosalsa",
-      "url": "https://www.ica.se/recept/gratinerade-nachos-med-mango-och-avokadosalsa-726399/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213798/cf_259/gratinerade_nachos_med_mango-_och_avokadosalsa.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 20,
-      "matched_count": 8,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "pastasås basilika",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven prästost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "avokado",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fryst mango",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "45,45",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "kokta svarta bönor",
-        "majskorn",
-        "vitlöksklyfta",
-        "olja",
-        "sambal oelek",
-        "salt",
-        "nachochips",
-        "lime",
-        "salt",
-        "peppar",
-        "lime",
-        "olja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 16,
-      "nutrition": {
-        "calories": "817 calories",
-        "protein": "21 g",
-        "fat": "43 g",
-        "carbs": "79 g"
-      }
-    },
-    {
-      "name": "Bön- och majsburgare med avokadokräm",
-      "url": "https://www.ica.se/recept/bon-och-majsburgare-med-avokadokram-722220/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_161133/cf_259/bon-_och_majsburgare_med_avokadokram.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 20,
-      "matched_count": 8,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "kokta kidneybönor",
-        "solroskärnor",
-        "spiskummin",
-        "salt",
-        "peppar",
-        "majskorn",
-        "olja",
-        "cayennepeppar",
-        "vitlöksklyfta",
-        "lime",
-        "kruka krispsallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 71,
-      "nutrition": {
-        "calories": "687 calories",
-        "protein": "20 g",
-        "fat": "33 g",
-        "carbs": "70 g"
       }
     },
     {
@@ -14185,7 +16347,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -14301,7 +16463,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -14343,122 +16505,6 @@
         "protein": "",
         "fat": "",
         "carbs": ""
-      }
-    },
-    {
-      "name": "Kycklingtacos med rostad majs och chipotlemajonnäs",
-      "url": "https://www.ica.se/recept/kycklingtacos-med-rostad-majs-och-chipotlemajonnas-724779/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_190189/cf_259/kycklingtacos_med_rostad_majs_och_chipotlemajonnas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 21,
-      "matched_count": 8,
-      "match_percentage": 38.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "ca 500 g kycklinglårfilé",
-          "deal_name": "Kycklinglårfilé",
-          "deal_price": "79.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,97",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "-  2 tsk chipotlepaste",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rökt paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "chipotlepaste",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smulad fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "picklad rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja till stekning",
-        "mald spiskummin",
-        "finhackade vitlöksklyftor",
-        "mald koriander",
-        "salt",
-        "nymalen svartpeppar",
-        "majskorn",
-        "salt",
-        "saft från 1 lime",
-        "majonnäs",
-        "salt",
-        "hackad färsk koriander",
-        "limeklyftor"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 25,
-      "nutrition": {
-        "calories": "591 calories",
-        "protein": "37 g",
-        "fat": "29 g",
-        "carbs": "44 g"
       }
     },
     {
@@ -14532,13 +16578,13 @@
         },
         {
           "ingredient": "frysta majskorn",
-          "deal_name": "Frysta Thaiboxar",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "3 för",
-          "ord_pris": "45:90",
-          "jfr_pris": "84:76-98:89",
-          "match_score": 0.75
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
           "ingredient": "matyoghurt",
@@ -14611,12 +16657,12 @@
         },
         {
           "ingredient": "sats honungsrostad savoykål",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -14746,11 +16792,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -14800,13 +16846,13 @@
         },
         {
           "ingredient": "kycklingbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "mjuka tunnbröd",
@@ -14840,12 +16886,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -14936,11 +16982,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -15012,11 +17058,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -15032,7 +17078,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -15203,12 +17249,12 @@
         },
         {
           "ingredient": "rostade havregryn, sesamfrön och russin",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -15406,7 +17452,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -15492,17 +17538,17 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -15515,7 +17561,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -15634,6 +17680,103 @@
       }
     },
     {
+      "name": "Isterband med ostgratinerad blomkål",
+      "url": "https://www.ica.se/recept/isterband-med-ostgratinerad-blomkal-723246/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_177095/cf_259/isterband_med_ostgratinerad_blomkal.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 7,
+      "match_percentage": 63.6,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 800 g blomkål",
+          "deal_name": "Blomkål",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "25",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grönsaksbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven västerbottensost",
+          "deal_name": "Västerbottensost®",
+          "deal_price": "89:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "135:00",
+          "jfr_pris": "197:78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "isterband",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "inlagda rödbetor",
+          "deal_name": "Rödbetor",
+          "deal_price": "12:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "12",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "mjölk",
+        "kruka persilja",
+        "buljongkokt potatis"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 5,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "807 calories",
+        "protein": "34 g",
+        "fat": "48 g",
+        "carbs": "56 g"
+      }
+    },
+    {
       "name": "Ädelostpasta med purjolök och bacon",
       "url": "https://www.ica.se/recept/adelostpasta-med-purjolok-och-bacon-750163/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/d6vzoipa1njlrox9ejro.jpg",
@@ -15664,13 +17807,13 @@
         },
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "pasta t ex linguine",
@@ -15694,12 +17837,12 @@
         },
         {
           "ingredient": "krämig mild ädelost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Ädelost",
+          "deal_price": "29:-",
           "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_unit": "/st",
+          "ord_pris": "37:95",
+          "jfr_pris": "207:14",
           "match_score": 0.9
         },
         {
@@ -15782,11 +17925,11 @@
         {
           "ingredient": "ca 500 g kebab",
           "deal_name": "Kebab",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "55:00-58:95",
-          "jfr_pris": "109:09",
+          "deal_price": "130:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "118,18",
           "match_score": 0.9
         },
         {
@@ -15802,11 +17945,11 @@
         {
           "ingredient": "kebabsås , röd eller vit eller båda",
           "deal_name": "Kebab",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "55:00-58:95",
-          "jfr_pris": "109:09",
+          "deal_price": "130:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "118,18",
           "match_score": 0.9
         }
       ],
@@ -15925,100 +18068,100 @@
       }
     },
     {
-      "name": "Vego tacos med tortillabröd",
-      "url": "https://www.ica.se/recept/vego-tacos-med-tortillabrod-728661/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241258/cf_259/vego_tacos_med_tortillabrod.jpg",
+      "name": "Kyckling med brysselkål, apelsinsås och gratäng",
+      "url": "https://www.ica.se/recept/kyckling-med-brysselkal-apelsinsas-och-gratang-726069/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_208657/cf_259/apelsinkyckling_med_brysselkal_och_gratang.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 7,
       "match_percentage": 63.6,
       "matched_ingredients": [
         {
-          "ingredient": "torr taco vegofärs",
-          "deal_name": "Färsk Vego",
-          "deal_price": "60:-",
+          "ingredient": "potatisgratäng",
+          "deal_name": "POTATISGRATÄNG",
+          "deal_price": "57.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "28,95",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "apelsin",
+          "deal_name": "Blodapelsiner i nät",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "36:90-39:90",
+          "jfr_pris": "20:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "brysselkål",
+          "deal_name": "BRYSSELKÅL I PÅSE",
+          "deal_price": "15:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ca 500 g tunnskivad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsolja",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "100",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "stor rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
+          "ingredient": "kycklingfond",
+          "deal_name": "Fond",
+          "deal_price": "60:-",
           "deal_store": "ICA Supermarket",
           "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
+          "ord_pris": "41:90",
+          "jfr_pris": "7:50",
           "match_score": 0.9
-        },
-        {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "tacosås",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
         }
       ],
       "unmatched_ingredients": [
-        "majskorn",
-        "isbergssalladshuvud",
-        "olja",
-        "ca 100 g tortillachips"
+        "salt",
+        "grovmalen svartpeppar",
+        "vatten",
+        "kruka persilja"
       ],
-      "time": "PT30M",
+      "time": "PT45M",
       "servings": "4",
-      "rating": 4.7,
-      "reviews": 69,
+      "rating": 4.6,
+      "reviews": 7,
       "nutrition": {
-        "calories": "567 calories",
-        "protein": "38 g",
-        "fat": "39 g",
-        "carbs": "84 g"
+        "calories": "581 calories",
+        "protein": "44 g",
+        "fat": "27 g",
+        "carbs": "37 g"
       }
     },
     {
@@ -16083,11 +18226,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -16150,12 +18293,12 @@
         },
         {
           "ingredient": "smulad fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -16238,13 +18381,13 @@
         },
         {
           "ingredient": "kycklingbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "rapsolja",
@@ -16316,6 +18459,104 @@
       }
     },
     {
+      "name": "Pizza med majs och fetaost",
+      "url": "https://www.ica.se/recept/pizza-med-majs-och-fetaost-729360/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241513/cf_259/pizza_med_majs_och_fetaost.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 7,
+      "match_percentage": 58.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "pizzadeg",
+          "deal_name": "PIZZAKIT, PIZZADEG",
+          "deal_price": "20:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "51,28",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "färskpressad limejuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven mild ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rökt paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "riven vitlöksklyfta",
+        "finrivet limeskal",
+        "salt",
+        "limeklyftor",
+        "fryst eller färsk koriander"
+      ],
+      "time": "PT30M",
+      "servings": "2",
+      "rating": 4.6,
+      "reviews": 25,
+      "nutrition": {
+        "calories": "1097 calories",
+        "protein": "40 g",
+        "fat": "66 g",
+        "carbs": "91 g"
+      }
+    },
+    {
       "name": "Allt på en plåt med majs, paprika och kycklinglårfilé",
       "url": "https://www.ica.se/recept/allt-pa-en-plat-med-majs-paprika-och-kycklinglarfile-728956/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241141/cf_259/allt_pa_en_plat_med_majs__paprika_och_kycklinglarfilé.jpg",
@@ -16336,12 +18577,12 @@
         },
         {
           "ingredient": "förkokta majskolvar",
-          "deal_name": "MAJSKOLVAR",
-          "deal_price": "35:-",
-          "deal_store": "Willys",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "43,75",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
@@ -16377,7 +18618,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -16610,6 +18851,104 @@
       }
     },
     {
+      "name": "Fiskgratäng med dill och tomat",
+      "url": "https://www.ica.se/recept/fiskgratang-med-dill-och-tomat-724538/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192947/cf_259/fiskgratang_med_dill_och_tomat.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 7,
+      "match_percentage": 58.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fiskbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "alaska pollock",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ask plommontomater eller valfria tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kruka sallad",
+          "deal_name": "Ekologisk sallad i påse",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "230,77",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölk",
+        "chilisås",
+        "salt",
+        "peppar",
+        "färsk eller fryst dill"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 52,
+      "nutrition": {
+        "calories": "620 calories",
+        "protein": "41 g",
+        "fat": "27 g",
+        "carbs": "49 g"
+      }
+    },
+    {
       "name": "Ryska gnocchi med lufttorkad skinka",
       "url": "https://www.ica.se/recept/ryska-gnocchi-med-lufttorkad-skinka-714011/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_39721/cf_259/ryska_gnocchi_med_lufttorkad_skinka.jpg",
@@ -16621,11 +18960,11 @@
         {
           "ingredient": "askar ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -16708,104 +19047,6 @@
       }
     },
     {
-      "name": "Champinjonsoppa",
-      "url": "https://www.ica.se/recept/champinjonsoppa-715952/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_69453/cf_259/champinjonsoppa.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 7,
-      "match_percentage": 58.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "konc grönsaksfond",
-          "deal_name": "Fond",
-          "deal_price": "60:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "41:90",
-          "jfr_pris": "7:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "kallt vatten",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "torkad timjan",
-        "mjölk",
-        "majsstärkelse",
-        "salt",
-        "peppar"
-      ],
-      "time": "PT60M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 411,
-      "nutrition": {
-        "calories": "675 calories",
-        "protein": "13 g",
-        "fat": "61 g",
-        "carbs": "20 g"
-      }
-    },
-    {
       "name": "Ryska gnocchi med lufttorkad skinka",
       "url": "https://www.ica.se/recept/ryska-gnocchi-med-lufttorkad-skinka-714011/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_39721/cf_259/ryska_gnocchi_med_lufttorkad_skinka.jpg",
@@ -16817,11 +19058,11 @@
         {
           "ingredient": "askar ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -16925,11 +19166,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -17000,105 +19241,6 @@
         "protein": "15 g",
         "fat": "29 g",
         "carbs": "25 g"
-      }
-    },
-    {
-      "name": "Nachotallrik",
-      "url": "https://www.ica.se/recept/nachotallrik-729736/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247937/cf_259/nachotallrik.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 7,
-      "match_percentage": 53.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "nötfärs eller blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "mild taco kryddmix",
-          "deal_name": "Mild kvarg/Grekisk Yoghurt",
-          "deal_price": "35:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "48:95-52:00",
-          "jfr_pris": "35:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "sallad",
-          "deal_name": "Socker- och salladsärtor i påse",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
-          "jfr_pris": "133:33",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tacosås",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "vatten",
-        "nachochips",
-        "majskorn",
-        "-  1 dl inlagd jalapeño",
-        "tärnad gurka"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 22,
-      "nutrition": {
-        "calories": "806 calories",
-        "protein": "40 g",
-        "fat": "43 g",
-        "carbs": "61 g"
       }
     },
     {
@@ -17272,7 +19414,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -17297,6 +19439,105 @@
         "protein": "36 g",
         "fat": "38 g",
         "carbs": "46 g"
+      }
+    },
+    {
+      "name": "Taco bowl",
+      "url": "https://www.ica.se/recept/taco-bowl-729345/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243339/cf_259/taco_bowl.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 7,
+      "match_percentage": 53.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kycklingfilé",
+          "deal_name": "Färsk kycklingfilé",
+          "deal_price": "119:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/kg",
+          "ord_pris": "179:00",
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kryddmix chili & lime taco",
+          "deal_name": "Pulled beef taco",
+          "deal_price": "62.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "170,00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fryst tärnad mango",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris",
+        "srirachasås",
+        "salt",
+        "olja",
+        "snackgurkor",
+        "kruka koriander"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 16,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -17440,7 +19681,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -17495,105 +19736,6 @@
         "protein": "37 g",
         "fat": "42 g",
         "carbs": "44 g"
-      }
-    },
-    {
-      "name": "Kalkongryta med paprika och basilika",
-      "url": "https://www.ica.se/recept/kalkongryta-med-paprika-och-basilika-728276/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_232673/cf_259/kalkongryta_med_paprika_och_basilika_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 7,
-      "match_percentage": 53.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "bananschalottenlökar",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kalkonbröstfilé",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "påse haricots verts",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "mjölk",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "färsk basilika"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 7,
-      "nutrition": {
-        "calories": "597 calories",
-        "protein": "35 g",
-        "fat": "30 g",
-        "carbs": "42 g"
       }
     },
     {
@@ -17846,7 +19988,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -17914,23 +20056,23 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "gul lök",
@@ -18154,11 +20296,11 @@
         {
           "ingredient": "getost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -18353,13 +20495,13 @@
         },
         {
           "ingredient": "nötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
+          "deal_name": "Nötter",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "jfr_pris": "163,33",
+          "match_score": 1.0
         },
         {
           "ingredient": "frukt",
@@ -18390,6 +20532,106 @@
         "protein": "15 g",
         "fat": "18 g",
         "carbs": "56 g"
+      }
+    },
+    {
+      "name": "Kycklingsnitzel med ljummen potatissallad",
+      "url": "https://www.ica.se/recept/kycklingsnitzel-med-ljummen-potatissallad-729208/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243317/cf_259/kycklingsnitzel_med_ljummen_potatissallad.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 7,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "rostad lök",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vetemjöl",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "kapris",
+        "smetana",
+        "curry",
+        "salt",
+        "peppar",
+        "olja",
+        "rödgrön kruksallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.9,
+      "reviews": 7,
+      "nutrition": {
+        "calories": "727 calories",
+        "protein": "45 g",
+        "fat": "34 g",
+        "carbs": "55 g"
       }
     },
     {
@@ -18653,12 +20895,12 @@
         },
         {
           "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -18753,12 +20995,12 @@
         },
         {
           "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -18853,12 +21095,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -18964,11 +21206,11 @@
         {
           "ingredient": "pizzaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -19053,22 +21295,22 @@
         },
         {
           "ingredient": "smulad labneh- eller fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "rostade pinjenötter eller solrosfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -19090,106 +21332,6 @@
         "protein": "31 g",
         "fat": "25 g",
         "carbs": "17 g"
-      }
-    },
-    {
-      "name": "Mörrumsgryta",
-      "url": "https://www.ica.se/recept/morrumsgryta-317139/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_39754/cf_259/morrumsgryta.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 7,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "laxfilé",
-          "deal_name": "Färsk laxfilé",
-          "deal_price": "149:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "149",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "fiskbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "grädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "knippe dill",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "portioner kokt potatis eller ris",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "morot",
-        "citron",
-        "vatten",
-        "vitvinsvinäger",
-        "- msk majsstärkelse",
-        "salt",
-        "vitpeppar"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 85,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -19264,11 +21406,11 @@
         {
           "ingredient": "pizzaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -19363,12 +21505,12 @@
         },
         {
           "ingredient": "pommes frites",
-          "deal_name": "Pommes Frites, Strips",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "28:95",
-          "jfr_pris": "15:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -19403,13 +21545,13 @@
       "matched_ingredients": [
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "morötter",
@@ -19463,12 +21605,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -19490,106 +21632,6 @@
         "protein": "30.2 g",
         "fat": "47.6 g",
         "carbs": "25.3 g"
-      }
-    },
-    {
-      "name": "Krämig laxgryta med räkor och dill",
-      "url": "https://www.ica.se/recept/kramig-laxgryta-med-rakor-och-dill-721466/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_153199/cf_259/kramig_laxgryta_med_rakor_och_dill.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 7,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "purjolök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "räkor i lake",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "spad från räkorna",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "vitt matlagningsvin",
-        "majsstärkelse",
-        "portionsbitar lax",
-        "salt",
-        "cayennepeppar",
-        "ask färsk dill"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 85,
-      "nutrition": {
-        "calories": "625 calories",
-        "protein": "30.1 g",
-        "fat": "33.2 g",
-        "carbs": "48 g"
       }
     },
     {
@@ -19643,13 +21685,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "skivad rökt kalkon",
@@ -19663,12 +21705,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -19894,43 +21936,124 @@
       }
     },
     {
-      "name": "Kyckling med potatis- och majssallad och äppelsås",
-      "url": "https://www.ica.se/recept/kyckling-med-potatis-och-majssallad-och-appelsas-729151/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_240428/cf_259/kyckling_med_potatis-_och_majssallad_och_appelsas.jpg",
+      "name": "Krispig kyckling-schnitzel med kapriskräm",
+      "url": "https://www.ica.se/recept/krispig-kyckling-schnitzel-med-kapriskram-721467/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_153248/cf_259/krispig_kycklingschnitzel_med_kapriskram.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 15,
       "matched_count": 7,
       "match_percentage": 46.7,
       "matched_ingredients": [
         {
-          "ingredient": "potatis",
+          "ingredient": "fast potatis",
           "deal_name": "Sötpotatis",
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/kg",
           "ord_pris": "49:95",
           "jfr_pris": null,
-          "match_score": 0.9
+          "match_score": 0.85
         },
         {
-          "ingredient": "salladslök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
           "match_score": 0.9
+        },
+        {
+          "ingredient": "ägg",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "körsbärstomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "dijonsenap",
+        "olja",
+        "kapris",
+        "citron",
+        "mâchesallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 35,
+      "nutrition": {
+        "calories": "767 calories",
+        "protein": "45.3 g",
+        "fat": "32.1 g",
+        "carbs": "69.8 g"
+      }
+    },
+    {
+      "name": "Kalkon i ugn med äpple och gräddsås",
+      "url": "https://www.ica.se/recept/kalkon-i-ugn-med-apple-och-graddsas-726192/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/bf7a43ibu3ry3miuup9t.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 7,
+      "match_percentage": 46.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
         },
         {
           "ingredient": "äpplen",
@@ -19943,55 +22066,75 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "grekisk yoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "honung",
-          "deal_name": "Blomsterhonung",
-          "deal_price": "55:-",
+          "ingredient": "krossade vitlöksklyftor",
+          "deal_name": "Krossade tomater",
+          "deal_price": "30:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "55",
+          "jfr_pris": "37,50",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "hel kalkon",
+          "deal_name": "Kalkonköttbullar/Kalkonfärs",
+          "deal_price": "57.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "144,75",
           "match_score": 0.9
         },
         {
-          "ingredient": "bbq-marinerade kycklingfiléer",
-          "deal_name": "Färsk kycklingfilé",
-          "deal_price": "119:-",
+          "ingredient": "konc kalvfond",
+          "deal_name": "Fond",
+          "deal_price": "60:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "179:00",
+          "deal_unit": "2 för",
+          "ord_pris": "41:90",
+          "jfr_pris": "7:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
           "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "ev 1 tsk majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "citron",
-        "olivolja",
+        "japansk soja",
         "salt",
-        "svartpeppar",
-        "majskorn",
-        "babyspenat",
+        "hackad färsk rosmarin",
+        "salt",
+        "ca 4 dl sky från kalkon",
+        "-  4 msk äppelmos",
         "salt",
         "svartpeppar"
       ],
-      "time": "PT45M",
-      "servings": "4",
+      "time": "PT90M",
+      "servings": "8-10",
       "rating": 4.7,
-      "reviews": 12,
+      "reviews": 117,
       "nutrition": {
-        "calories": "832 calories",
-        "protein": "48 g",
+        "calories": "896 calories",
+        "protein": "107 g",
         "fat": "46 g",
-        "carbs": "53 g"
+        "carbs": "13 g"
       }
     },
     {
@@ -20025,13 +22168,13 @@
         },
         {
           "ingredient": "paket, skivat bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "tomat",
@@ -20237,13 +22380,13 @@
         },
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "crème fraiche",
@@ -20271,7 +22414,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -20295,107 +22438,6 @@
         "protein": "35 g",
         "fat": "60 g",
         "carbs": "137 g"
-      }
-    },
-    {
-      "name": "Färspanna med potatis och paprika",
-      "url": "https://www.ica.se/recept/farspanna-med-potatis-och-paprika-728643/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_237147/cf_259/farspanna_med_potatis_och_paprika.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 7,
-      "match_percentage": 46.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "nötfärs",
-          "deal_name": "Umamifärs",
-          "deal_price": null,
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "54:90",
-          "jfr_pris": "79:80",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "köttbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gul paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "morot",
-        "olja",
-        "salt",
-        "peppar",
-        "torkad oregano",
-        "tomatpuré",
-        "mjölk",
-        "majsstärkelse"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "561 calories",
-        "protein": "34 g",
-        "fat": "25 g",
-        "carbs": "46 g"
       }
     },
     {
@@ -20873,12 +22915,12 @@
         },
         {
           "ingredient": "rostade pumpakärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -20974,12 +23016,12 @@
         },
         {
           "ingredient": "ev rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -21005,124 +23047,33 @@
       }
     },
     {
-      "name": "Enchiladas med avokadosalsa",
-      "url": "https://www.ica.se/recept/enchiladas-med-avokadosalsa-726385/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213237/cf_259/enchiladas_med_avokadosalsa.jpg",
+      "name": "Pulled beans i tortillabröd cheddarkräm",
+      "url": "https://www.ica.se/recept/pulled-beans-i-tortillabrod-cheddarkram-726302/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210514/cf_259/pulled_beans_i_tortillabrod_cheddarkram.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 15,
       "matched_count": 7,
       "match_percentage": 46.7,
       "matched_ingredients": [
         {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "pastasås vitlök",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven prästost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
           "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ask plommontomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "spiskummin",
-        "kokta kidneybönor",
-        "majskorn",
-        "salt",
-        "peppar",
-        "lime",
-        "olivolja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 26,
-      "nutrition": {
-        "calories": "906 calories",
-        "protein": "44 g",
-        "fat": "44 g",
-        "carbs": "77 g"
-      }
-    },
-    {
-      "name": "Enkel vegansk tacopaj",
-      "url": "https://www.ica.se/recept/enkel-vegansk-tacopaj-725958/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203487/cf_259/enkel_vegansk_tacopaj.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 7,
-      "match_percentage": 46.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "kylskåpskallt mjölkfritt margarin",
-          "deal_name": "LAKTOSFRI MJÖLK",
-          "deal_price": "42:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
         },
         {
           "ingredient": "vetemjöl",
@@ -21135,75 +23086,65 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "iskallt vatten",
-          "deal_name": "TE",
-          "deal_price": "39:-",
+          "ingredient": "riven cheddarost",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
           "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
-          "ingredient": "gula lökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "växtbaserad crème fraiche med paprika och chili",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
           "match_score": 0.9
         },
         {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ask cocktailtomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
+          "ingredient": "pulled beans",
+          "deal_name": "PULLED PORK",
+          "deal_price": "39.90:-",
           "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "72,55",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "små mjuka tortillabröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "vitlöksklyftor",
-        "olja",
-        "sojafärs",
-        "mald spiskummin",
-        "mald  koriander",
-        "majskorn",
+        "avrunnen inlagd jalapeño",
+        "mjölk",
         "salt",
-        "svartpeppar"
+        "svartpeppar",
+        "silverlök",
+        "kruka krispsallad",
+        "spiskummin",
+        "ev färsk koriander"
       ],
-      "time": "PT90M",
+      "time": "PT30M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 33,
+      "rating": 4.9,
+      "reviews": 15,
       "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
+        "calories": "444 calories",
+        "protein": "19 g",
+        "fat": "21 g",
+        "carbs": "43 g"
       }
     },
     {
@@ -21380,7 +23321,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -21513,6 +23454,108 @@
       }
     },
     {
+      "name": "Sötpotatis texmex",
+      "url": "https://www.ica.se/recept/sotpotatis-texmex-729303/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243345/cf_259/sotpotatis_texmex___.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 16,
+      "matched_count": 7,
+      "match_percentage": 43.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "sötpotatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "salladslök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "miniplommontomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "salt",
+        "peppar",
+        "kokta svarta bönor",
+        "olivolja",
+        "chiliflakes",
+        "kruka koriander",
+        "lime",
+        "cosmopolitansallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 15,
+      "nutrition": {
+        "calories": "887 calories",
+        "protein": "19 g",
+        "fat": "44 g",
+        "carbs": "97 g"
+      }
+    },
+    {
       "name": "Tomatsoppa med fänkål och vispad mozzarella",
       "url": "https://www.ica.se/recept/tomatsoppa-med-fankal-och-vispad-mozzarella-729481/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243828/cf_259/tomatsoppa_med_fankal_och_vispad_mozzarella.jpg",
@@ -21584,7 +23627,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -21676,7 +23719,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -21685,13 +23728,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -21962,11 +24005,11 @@
         {
           "ingredient": "ostskivor",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -22074,11 +24117,11 @@
         {
           "ingredient": "riven prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -22195,12 +24238,12 @@
         },
         {
           "ingredient": "rostade pumpakärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -22277,13 +24320,13 @@
         },
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "rapsolja",
@@ -22399,12 +24442,12 @@
         },
         {
           "ingredient": "rostade frön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -22502,7 +24545,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -22604,7 +24647,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -22778,13 +24821,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "omogen mango",
@@ -22799,7 +24842,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -22944,109 +24987,6 @@
       }
     },
     {
-      "name": "Svamppasta med timjanrostad rotselleri",
-      "url": "https://www.ica.se/recept/svamppasta-med-timjanrostad-rotselleri-728442/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233991/cf_259/svamppasta_med_timjanrostad_rotselleri.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 17,
-      "matched_count": 7,
-      "match_percentage": 41.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "rotselleri",
-          "deal_name": "Rotselleri, Kålrot",
-          "deal_price": "15:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "15",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kastanjechampinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "grönsaksbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färsk pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "romanticatomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olivolja",
-        "kruka timjan",
-        "salt",
-        "peppar",
-        "olivolja",
-        "vitlöksklyfta",
-        "vitt matlagningsvin",
-        "vatten",
-        "majsstärkelse",
-        "mâchesallad"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 13,
-      "nutrition": {
-        "calories": "490 calories",
-        "protein": "12 g",
-        "fat": "26 g",
-        "carbs": "47 g"
-      }
-    },
-    {
       "name": "Linsgryta med kokosmjölk",
       "url": "https://www.ica.se/recept/linsgryta-med-kokosmjolk-724788/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_250515/cf_259/linsgryta_med_kokosmjolk.jpg",
@@ -23174,7 +25114,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -23201,7 +25141,7 @@
         {
           "ingredient": "minimozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -23428,12 +25368,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -23459,6 +25399,110 @@
         "protein": "15 g",
         "fat": "45 g",
         "carbs": "59 g"
+      }
+    },
+    {
+      "name": "Pannbiff med löksås",
+      "url": "https://www.ica.se/recept/pannbiff-med-loksas-727247/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_245083/cf_259/pannbiff_med_loksas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 7,
+      "match_percentage": 38.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "blandfärs eller hushållsfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör eller olja",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "köttbuljongtärning eller motsvarande mängd fond",
+          "deal_name": "Fond",
+          "deal_price": "60:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "41:90",
+          "jfr_pris": "7:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölk",
+        "dijonsenap",
+        "salt",
+        "peppar",
+        "olja",
+        "hackad fryst eller färsk lök",
+        "mjölk",
+        "mellangrädde",
+        "japansk soja",
+        "salt",
+        "peppar"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 143,
+      "nutrition": {
+        "calories": "721 calories",
+        "protein": "34 g",
+        "fat": "40 g",
+        "carbs": "54 g"
       }
     },
     {
@@ -23523,21 +25567,21 @@
         {
           "ingredient": "ostronskivling",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -23636,12 +25680,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -23774,110 +25818,6 @@
       }
     },
     {
-      "name": "Cheddarpaj med kryddstekt kyckling",
-      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
-      "category": "Huvudrätt,Middag,Brunch",
-      "total_ingredients": 18,
-      "matched_count": 7,
-      "match_percentage": 38.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "färsk pajdeg",
-        "mjölk",
-        "salt",
-        "svartpeppar",
-        "oregano",
-        "rosmarin",
-        "salt",
-        "peppar",
-        "ca 600 g minutfilé av kyckling",
-        "citron",
-        "krispsallad"
-      ],
-      "time": "PT45M",
-      "servings": "8 bufféportioner",
-      "rating": 4.8,
-      "reviews": 27,
-      "nutrition": {
-        "calories": "493 calories",
-        "protein": "30 g",
-        "fat": "34 g",
-        "carbs": "17 g"
-      }
-    },
-    {
       "name": "Ugnsratatouille med bakat ägg",
       "url": "https://www.ica.se/recept/ugnsratatouille-med-bakat-agg-727150/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_222607/cf_259/ugnsratatouille_med_bakat_agg_.jpg",
@@ -23982,224 +25922,56 @@
       }
     },
     {
-      "name": "Cheddarpaj med kryddstekt kyckling",
-      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
-      "category": "Huvudrätt,Middag,Brunch",
-      "total_ingredients": 18,
-      "matched_count": 7,
-      "match_percentage": 38.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "färsk pajdeg",
-        "mjölk",
-        "salt",
-        "svartpeppar",
-        "oregano",
-        "rosmarin",
-        "salt",
-        "peppar",
-        "ca 600 g minutfilé av kyckling",
-        "citron",
-        "krispsallad"
-      ],
-      "time": "PT45M",
-      "servings": "8 bufféportioner",
-      "rating": 4.8,
-      "reviews": 27,
-      "nutrition": {
-        "calories": "493 calories",
-        "protein": "30 g",
-        "fat": "34 g",
-        "carbs": "17 g"
-      }
-    },
-    {
-      "name": "Cheddarpaj med kryddstekt kyckling",
-      "url": "https://www.ica.se/recept/cheddarpaj-med-kryddstekt-kyckling-726673/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213604/cf_259/cheddarpaj_med_kryddstekt_kyckling.jpg",
-      "category": "Huvudrätt,Middag,Brunch",
-      "total_ingredients": 18,
-      "matched_count": 7,
-      "match_percentage": 38.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "färsk pajdeg",
-        "mjölk",
-        "salt",
-        "svartpeppar",
-        "oregano",
-        "rosmarin",
-        "salt",
-        "peppar",
-        "ca 600 g minutfilé av kyckling",
-        "citron",
-        "krispsallad"
-      ],
-      "time": "PT45M",
-      "servings": "8 bufféportioner",
-      "rating": 4.8,
-      "reviews": 27,
-      "nutrition": {
-        "calories": "493 calories",
-        "protein": "30 g",
-        "fat": "34 g",
-        "carbs": "17 g"
-      }
-    },
-    {
-      "name": "Wokad biff med bambuskott",
-      "url": "https://www.ica.se/recept/wokad-biff-med-bambuskott-726364/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_209525/cf_259/wokad_biff_med_bambuskott.jpg",
+      "name": "Hemgjorda fiskbullar med ingefära och nudlar",
+      "url": "https://www.ica.se/recept/hemgjorda-fiskbullar-med-ingefara-och-nudlar-726652/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213081/cf_259/hemgjorda_fiskbullar_med_ingefara_och_nudlar.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 18,
       "matched_count": 7,
       "match_percentage": 38.9,
       "matched_ingredients": [
         {
-          "ingredient": "jasminris eller äggnudlar",
+          "ingredient": "äggvita",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hönsbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vit misopasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ramennudlar",
           "deal_name": "NUDLAR",
           "deal_price": "19.90:-",
           "deal_store": "Willys",
@@ -24209,88 +25981,152 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
+          "ingredient": "färska böngroddar",
+          "deal_name": "FÄRSKA KRYDDOR 15-25G",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
+          "jfr_pris": "660",
+          "match_score": 0.75
         },
         {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
+          "ingredient": "rostade sesamfrön",
+          "deal_name": "Rosta",
           "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ostronsås",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "konc oxfond",
-          "deal_name": "Fond",
-          "deal_price": "60:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "41:90",
-          "jfr_pris": "7:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "finskurna salladslökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
+          "jfr_pris": "33,33",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "ca 450 g ryggbiff",
-        "vitlöksklyfta",
-        "japansk soja",
-        "strösocker",
-        "crema di balsamico",
-        "majsstärkelse",
-        "vatten",
-        "sesamolja",
+        "skinnfri torskfilé",
         "salt",
-        "svartpeppar",
-        "skivade bambuskott"
+        "hackad chilifrukt",
+        "finriven  ingefära",
+        "finrivet limeskal",
+        "finriven vitlöksklyfta",
+        "hackad koriander",
+        "vatten",
+        "sambal oelek",
+        "pak choi",
+        "färsk koriander"
       ],
-      "time": "PT30M",
+      "time": "PT60M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 85,
+      "rating": 4.6,
+      "reviews": 10,
       "nutrition": {
-        "calories": "498 calories",
-        "protein": "33 g",
-        "fat": "12 g",
-        "carbs": "62 g"
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Hemgjorda fiskbullar med ingefära och nudlar",
+      "url": "https://www.ica.se/recept/hemgjorda-fiskbullar-med-ingefara-och-nudlar-726652/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213081/cf_259/hemgjorda_fiskbullar_med_ingefara_och_nudlar.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 7,
+      "match_percentage": 38.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "äggvita",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hönsbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vit misopasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ramennudlar",
+          "deal_name": "NUDLAR",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "213,98",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färska böngroddar",
+          "deal_name": "FÄRSKA KRYDDOR 15-25G",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "660",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "rostade sesamfrön",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "skinnfri torskfilé",
+        "salt",
+        "hackad chilifrukt",
+        "finriven  ingefära",
+        "finrivet limeskal",
+        "finriven vitlöksklyfta",
+        "hackad koriander",
+        "vatten",
+        "sambal oelek",
+        "pak choi",
+        "färsk koriander"
+      ],
+      "time": "PT60M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 10,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -24335,11 +26171,11 @@
         {
           "ingredient": "riven prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -24365,7 +26201,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -24459,11 +26295,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -24564,7 +26400,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -24868,13 +26704,13 @@
         },
         {
           "ingredient": "frysta majskorn",
-          "deal_name": "Frysta Thaiboxar",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "3 för",
-          "ord_pris": "45:90",
-          "jfr_pris": "84:76-98:89",
-          "match_score": 0.75
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
           "ingredient": "smör",
@@ -24973,13 +26809,13 @@
         },
         {
           "ingredient": "frysta majskorn",
-          "deal_name": "Frysta Thaiboxar",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "3 för",
-          "ord_pris": "45:90",
-          "jfr_pris": "84:76-98:89",
-          "match_score": 0.75
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         },
         {
           "ingredient": "smör",
@@ -25028,6 +26864,112 @@
       }
     },
     {
+      "name": "Färsbiffar med rostad pumpa och spenat",
+      "url": "https://www.ica.se/recept/farsbiffar-med-rostad-pumpa-och-spenat-729096/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241658/cf_259/farsbiffar_med_rostad_pumpa_och_spenat.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 20,
+      "matched_count": 7,
+      "match_percentage": 35.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödlökar",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "honung",
+          "deal_name": "Blomsterhonung",
+          "deal_price": "55:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "55",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "hokkaido pumpa",
+        "olja",
+        "salt",
+        "peppar",
+        "babyspenat",
+        "salt",
+        "senap",
+        "peppar",
+        "mjölk",
+        "olja",
+        "mjölk",
+        "torkad timjan",
+        "japansk soja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 6,
+      "nutrition": {
+        "calories": "715 calories",
+        "protein": "35 g",
+        "fat": "36 g",
+        "carbs": "58 g"
+      }
+    },
+    {
       "name": "Kebabgryta",
       "url": "https://www.ica.se/recept/kebabgryta-750370/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/cnmp1tyzbyftdbltjnoz.jpg",
@@ -25059,11 +27001,11 @@
         {
           "ingredient": "kebab",
           "deal_name": "Kebab",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "55:00-58:95",
-          "jfr_pris": "109:09",
+          "deal_price": "130:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "118,18",
           "match_score": 1.0
         },
         {
@@ -25099,7 +27041,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -25368,17 +27310,17 @@
         {
           "ingredient": "påse riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -25388,7 +27330,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -25451,6 +27393,222 @@
         "protein": "21 g",
         "fat": "26 g",
         "carbs": "67 g"
+      }
+    },
+    {
+      "name": "Quinoaburgare med sötpotatisfrites",
+      "url": "https://www.ica.se/recept/quinoaburgare-med-sotpotatisfrites-721451/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_152893/cf_259/quinoaburgare_med_sotpotatisfrites.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 21,
+      "matched_count": 7,
+      "match_percentage": 33.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "sötpotatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "yoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "cm strimlad purjolök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "hackad persilja",
+          "deal_name": "BLADPERSILJA 250G",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "79,60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hamburgerbröd",
+          "deal_name": "Hamburgerbröd",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "tomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mix till quinoaburgare",
+        "olivolja",
+        "havssalt",
+        "svartpeppar",
+        "majonnäs",
+        "dijonsenap",
+        "örtsalt",
+        "tabasco",
+        "ca 150 g strimlad rödbeta",
+        "ca 300 g strimlad rödkål",
+        "salladsblad",
+        "picklad lök",
+        "majonnäs",
+        "chilisås eller ketchup"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Fiskgratäng med hummer",
+      "url": "https://www.ica.se/recept/fiskgratang-med-hummer-729620/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_245757/cf_259/fiskgratang_med_hummer.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 23,
+      "matched_count": 7,
+      "match_percentage": 30.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "-  2 msk majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färskpressad citronjuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "äggulor",
+          "deal_name": "ÄGG, FRIGÅENDE",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "kokta humrar",
+        "vitlöksklyfta",
+        "timjankvistar",
+        "tomatpuré",
+        "vitt vin",
+        "vatten",
+        "salt",
+        "mjölig potatis",
+        "finrivet citronskal",
+        "svartpeppar",
+        "torskfilé",
+        "salt",
+        "fänkål",
+        "olja",
+        "färsk bladspenat",
+        "plockad dill"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 18,
+      "nutrition": {
+        "calories": "1197 calories",
+        "protein": "61 g",
+        "fat": "74 g",
+        "carbs": "55 g"
       }
     },
     {
@@ -25625,7 +27783,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -25736,7 +27894,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -25837,21 +27995,21 @@
         {
           "ingredient": "sats råkostsallad",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "rostade pumpakärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -25931,11 +28089,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -26015,7 +28173,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -26099,12 +28257,12 @@
         },
         {
           "ingredient": "hackade rostade nötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -26399,12 +28557,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -26495,7 +28653,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -26515,11 +28673,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -26590,21 +28748,21 @@
         {
           "ingredient": "kebab",
           "deal_name": "Kebab",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "55:00-58:95",
-          "jfr_pris": "109:09",
+          "deal_price": "130:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "118,18",
           "match_score": 1.0
         },
         {
           "ingredient": "kebabrullebröd",
           "deal_name": "Kebab",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "55:00-58:95",
-          "jfr_pris": "109:09",
+          "deal_price": "130:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "118,18",
           "match_score": 0.9
         },
         {
@@ -26632,6 +28790,92 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Tacosoppa",
+      "url": "https://www.ica.se/recept/tacosoppa-725665/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202133/cf_259/tacosoppa.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 9,
+      "matched_count": 6,
+      "match_percentage": 66.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "nötfärs",
+          "deal_name": "Umamifärs",
+          "deal_price": null,
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "54:90",
+          "jfr_pris": "79:80",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "bakpotatisar",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "taco kryddmix",
+          "deal_name": "Pulled beef taco",
+          "deal_price": "62.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "170,00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "passerade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "köttbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "nachochips",
+        "olja",
+        "vatten"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 158,
+      "nutrition": {
+        "calories": "591 calories",
+        "protein": "41 g",
+        "fat": "24 g",
+        "carbs": "49 g"
       }
     },
     {
@@ -26665,12 +28909,12 @@
         },
         {
           "ingredient": "rostade kokoschips",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -26741,12 +28985,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -26903,13 +29147,13 @@
       "matched_ingredients": [
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "ägg",
@@ -26953,12 +29197,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -26999,12 +29243,12 @@
         },
         {
           "ingredient": "sats honungsrostad savoykål",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -27054,6 +29298,93 @@
         "nymalen salt och svartpeppar"
       ],
       "time": "PT90M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 10,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Enchiladas med vegofärs",
+      "url": "https://www.ica.se/recept/enchiladas-med-vegofars-730395/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/swz1w0go5r35b8c0hhgg.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 10,
+      "matched_count": 6,
+      "match_percentage": 60.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "passerade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "stacky´s smartare färs eller annan vegofärs",
+          "deal_name": "Färsk Vego",
+          "deal_price": "60:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "100",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "kryddmix enchilada",
+        "vatten",
+        "isbergssalladshuvud"
+      ],
+      "time": "PT45M",
       "servings": "4",
       "rating": 4.8,
       "reviews": 10,
@@ -27115,12 +29446,12 @@
         },
         {
           "ingredient": "hackade, rostade mandlar",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -27212,12 +29543,12 @@
         },
         {
           "ingredient": "salsa på rostad majs",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         }
       ],
@@ -27387,11 +29718,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -27500,39 +29831,29 @@
       }
     },
     {
-      "name": "Pasta med bacon och ostssallad",
-      "url": "https://www.ica.se/recept/pasta-med-bacon-och-ostssallad-722370/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_162823/cf_259/pasta_med_bacon_och_ostssallad.jpg",
+      "name": "Snabb torskgryta med morötter",
+      "url": "https://www.ica.se/recept/snabb-torskgryta-med-morotter-726260/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_212592/cf_259/snabb_torskgryta_med_morotter.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 10,
       "matched_count": 6,
       "match_percentage": 60.0,
       "matched_ingredients": [
         {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "påse morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
           "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "klippt bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
@@ -27549,41 +29870,51 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "salladsost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ingredient": "förp  soppa",
+          "deal_name": "KYLD SOPPA",
+          "deal_price": "48:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
+          "ingredient": "fiskbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "mjölk",
-        "majsstärkelse",
-        "peppar",
-        "majskorn"
+        "torskfilé",
+        "olja",
+        "salt",
+        "peppar"
       ],
-      "time": "PT30M",
+      "time": "PT45M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 36,
+      "reviews": 11,
       "nutrition": {
-        "calories": "772 calories",
-        "protein": "29 g",
-        "fat": "43 g",
-        "carbs": "64 g"
+        "calories": "492 calories",
+        "protein": "37 g",
+        "fat": "14 g",
+        "carbs": "49 g"
       }
     },
     {
@@ -27607,13 +29938,13 @@
         },
         {
           "ingredient": "handskalade räkor i lake",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "zucchini",
@@ -27801,22 +30132,22 @@
         },
         {
           "ingredient": "rostade frön och nötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "smulad fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -27845,94 +30176,6 @@
         "protein": "17 g",
         "fat": "32 g",
         "carbs": "19 g"
-      }
-    },
-    {
-      "name": "Isterband med ostgratinerad blomkål",
-      "url": "https://www.ica.se/recept/isterband-med-ostgratinerad-blomkal-723246/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_177095/cf_259/isterband_med_ostgratinerad_blomkal.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 6,
-      "match_percentage": 54.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "ca 800 g blomkål",
-          "deal_name": "Blomkål",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "25",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "grönsaksbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven västerbottensost",
-          "deal_name": "Västerbottensost®",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "135:00",
-          "jfr_pris": "197:78",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "isterband",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "inlagda rödbetor",
-          "deal_name": "Rödbetor",
-          "deal_price": "12:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "12",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "salt",
-        "mjölk",
-        "majsstärkelse",
-        "kruka persilja",
-        "buljongkokt potatis"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 5,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "807 calories",
-        "protein": "34 g",
-        "fat": "48 g",
-        "carbs": "56 g"
       }
     },
     {
@@ -28085,11 +30328,11 @@
         {
           "ingredient": "ostsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -28109,6 +30352,94 @@
         "protein": "22 g",
         "fat": "24 g",
         "carbs": "61 g"
+      }
+    },
+    {
+      "name": "Sallad med ugnsrostade rödbetor, kyckling och fetaost",
+      "url": "https://www.ica.se/recept/sallad-med-ugnsrostade-rodbetor-kyckling-och-fetaost-725868/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202462/cf_259/sallad_med_ugnsrostade_rodbetor__kyckling_och_fetaost.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 6,
+      "match_percentage": 54.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "sats pocherad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "sats ugnsrostade rödbetor",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kokt matvete",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "yoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse blandsallad",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "sats frömix",
+        "kruka basilika",
+        "olivolja",
+        "salt",
+        "svartpeppar"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 6,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -28288,6 +30619,94 @@
       }
     },
     {
+      "name": "Fläsknoisetter med rostad majs och vitlöksdipp",
+      "url": "https://www.ica.se/recept/flasknoisetter-med-rostad-majs-och-vitloksdipp-726164/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_211547/cf_259/flasknoisetter_med_rostad_majs_och_vitloksdipp.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 6,
+      "match_percentage": 54.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "paprikapulver",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 500 g fläskytterfilé",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "vitlöksklyfta",
+        "romansallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 12,
+      "nutrition": {
+        "calories": "602 calories",
+        "protein": "29 g",
+        "fat": "30 g",
+        "carbs": "51 g"
+      }
+    },
+    {
       "name": "Fläskkarré med vitlöksyoghurt och rostade rotfrukter",
       "url": "https://www.ica.se/recept/flaskkarre-med-vitloksyoghurt-och-rostade-rotfrukter-726536/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_215288/cf_259/flaskkarré_med_vitloksyoghurt_och_rostade_rotfrukter.jpg",
@@ -28376,6 +30795,94 @@
       }
     },
     {
+      "name": "Toast med lammfärsbiffar och chèvre",
+      "url": "https://www.ica.se/recept/toast-med-lammfarsbiffar-och-chevre-725331/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248285/cf_259/toast_med_lammfarsbiffar_och_chèvre.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 6,
+      "match_percentage": 54.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "sats tomatsallad med rostade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "lammfärsbiffar",
+          "deal_name": "Färsk biff",
+          "deal_price": "59.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "332,78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ca 200 g getost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "skivor levainbröd",
+          "deal_name": "Levainbröd",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "44:90",
+          "jfr_pris": "46:15",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "blandad sallad",
+          "deal_name": "Ekologisk sallad i påse",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "230,77",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "frysta tinade sojabönor",
+          "deal_name": "Frysta Thaiboxar",
+          "deal_price": "89:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "3 för",
+          "ord_pris": "45:90",
+          "jfr_pris": "84:76-98:89",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "vitvinsvinäger",
+        "dijonsenap",
+        "torkad örtkrydda",
+        "oliver"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 5,
+      "reviews": 10,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
       "name": "Krämig paprikapasta med rosmarin och kronärtskockor",
       "url": "https://www.ica.se/recept/kramig-paprikapasta-med-rosmarin-och-kronartskockor-726443/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213489/cf_259/kramig_paprikapasta_med_rosmarin_och_kronartskockor.jpg",
@@ -28400,7 +30907,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -28613,7 +31120,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -28752,7 +31259,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -28880,7 +31387,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -28901,6 +31408,94 @@
         "protein": "35 g",
         "fat": "37 g",
         "carbs": "40 g"
+      }
+    },
+    {
+      "name": "Asiatisk kycklingsallad",
+      "url": "https://www.ica.se/recept/asiatisk-kycklingsallad-281308/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_13806/cf_259/asiatisk_kycklingsallad.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 6,
+      "match_percentage": 54.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "grillad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "-  7 salladslökar",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "limejuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färsk mango",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "sallad",
+          "deal_name": "Socker- och salladsärtor i påse",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "29:95-34:95",
+          "jfr_pris": "133:33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "bröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "röd chilifrukt",
+        "kruka koriander",
+        "-  2 1/2 dl sataysås",
+        "salt",
+        "peppar"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.9,
+      "reviews": 13,
+      "nutrition": {
+        "calories": "556 calories",
+        "protein": "",
+        "fat": "27.6 g",
+        "carbs": ""
       }
     },
     {
@@ -29023,7 +31618,7 @@
         {
           "ingredient": "starkt kaffe",
           "deal_name": "Kaffe",
-          "deal_price": "Medlemspris",
+          "deal_price": "109:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -29122,7 +31717,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -29131,12 +31726,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -29180,12 +31775,12 @@
       "matched_ingredients": [
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -29256,6 +31851,95 @@
         "protein": "33 g",
         "fat": "43 g",
         "carbs": "77 g"
+      }
+    },
+    {
+      "name": "Fläskytterfilé i dragonsås med pressad potatis",
+      "url": "https://www.ica.se/recept/flaskytterfile-i-dragonsas-med-pressad-potatis-729517/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246458/cf_259/flaskytterfilé_i_dragonsas_med_pressad_potatis.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 6,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "ca 650 g fläskytterfilé",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "köttbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "mjölk",
+        "vitvinsvinäger",
+        "torkad dragon"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 60,
+      "nutrition": {
+        "calories": "641 calories",
+        "protein": "44 g",
+        "fat": "32 g",
+        "carbs": "41 g"
       }
     },
     {
@@ -29409,11 +32093,11 @@
         {
           "ingredient": "riven parmesan eller annan lagrad hårdost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -29498,11 +32182,11 @@
         {
           "ingredient": "riven parmesan eller annan lagrad hårdost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -29577,7 +32261,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -29587,11 +32271,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -29646,7 +32330,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -29675,12 +32359,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -29701,95 +32385,6 @@
         "protein": "17 g",
         "fat": "18 g",
         "carbs": "64 g"
-      }
-    },
-    {
-      "name": "Pizza med majs och fetaost",
-      "url": "https://www.ica.se/recept/pizza-med-majs-och-fetaost-729360/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241513/cf_259/pizza_med_majs_och_fetaost.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 6,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "pizzadeg",
-          "deal_name": "PIZZAKIT, PIZZADEG",
-          "deal_price": "20:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "51,28",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "färskpressad limejuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven mild ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rökt paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "riven vitlöksklyfta",
-        "finrivet limeskal",
-        "salt",
-        "majskorn",
-        "limeklyftor",
-        "fryst eller färsk koriander"
-      ],
-      "time": "PT30M",
-      "servings": "2",
-      "rating": 4.6,
-      "reviews": 25,
-      "nutrition": {
-        "calories": "1097 calories",
-        "protein": "40 g",
-        "fat": "66 g",
-        "carbs": "91 g"
       }
     },
     {
@@ -29943,11 +32538,11 @@
         {
           "ingredient": "grovt riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -30200,11 +32795,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -30416,6 +33011,95 @@
       }
     },
     {
+      "name": "Kyckling tikka masala med ärt- och spetskålssallad",
+      "url": "https://www.ica.se/recept/kyckling-tikka-masala-med-art-och-spetskalssallad-725405/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_199126/cf_259/kyckling_tikka_masala_med_art-_och_spetskalssallad.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 6,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "gula lökar",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "gröna ärtor",
+          "deal_name": "GRÖNA KÄRNFRIA DRUVOR I ASK",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "50",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "matlagningsyoghurt",
+          "deal_name": "Yoghurt",
+          "deal_price": "45:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "30:90-32:90",
+          "jfr_pris": "22:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spetskålshuvud",
+          "deal_name": "HEL SPETSKÅL",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "19,90",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "naanbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "svartpeppar",
+        "tikka masala sås",
+        "lime",
+        "ris"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 6,
+      "nutrition": {
+        "calories": "463 calories",
+        "protein": "41 g",
+        "fat": "22 g",
+        "carbs": "22 g"
+      }
+    },
+    {
       "name": "Libapizza med zucchini och tomater",
       "url": "https://www.ica.se/recept/libapizza-med-zucchini-och-tomater-726928/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_215355/cf_259/libapizza_med_zucchini_och_tomater.jpg",
@@ -30467,11 +33151,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -30502,95 +33186,6 @@
         "protein": "",
         "fat": "",
         "carbs": ""
-      }
-    },
-    {
-      "name": "Fiskgratäng med dill och tomat",
-      "url": "https://www.ica.se/recept/fiskgratang-med-dill-och-tomat-724538/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192947/cf_259/fiskgratang_med_dill_och_tomat.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 6,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "fiskbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "alaska pollock",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ask plommontomater eller valfria tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kruka sallad",
-          "deal_name": "Ekologisk sallad i påse",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "230,77",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölk",
-        "chilisås",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "färsk eller fryst dill"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 52,
-      "nutrition": {
-        "calories": "620 calories",
-        "protein": "41 g",
-        "fat": "27 g",
-        "carbs": "49 g"
       }
     },
     {
@@ -30734,11 +33329,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -30803,7 +33398,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -30822,12 +33417,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -30950,6 +33545,95 @@
       }
     },
     {
+      "name": "Enchiladas med majs och gurka",
+      "url": "https://www.ica.se/recept/enchiladas-med-majs-och-gurka-725820/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_208320/cf_259/enchiladas_med_majs_och_gurka.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 12,
+      "matched_count": 6,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 500 g blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd",
+          "deal_name": "Tortillabröd, Tacosås, Chips",
+          "deal_price": "100:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "10 för",
+          "ord_pris": "17:50-31:90",
+          "jfr_pris": "31:25-54:05",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris eller annat gryn",
+        "olivolja",
+        "enchilada kryddmix",
+        "tomatpuré",
+        "vatten",
+        "chunky salsa"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 10,
+      "nutrition": {
+        "calories": "937 calories",
+        "protein": "43 g",
+        "fat": "33 g",
+        "carbs": "113 g"
+      }
+    },
+    {
       "name": "Broccolisoppa med fänkålsfrö och salsiccia",
       "url": "https://www.ica.se/recept/broccolisoppa-med-fankalsfro-och-salsiccia-715838/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_69682/cf_259/broccolisoppa_med_fankalsfro_och_salsiccia.jpg",
@@ -31036,6 +33720,96 @@
         "protein": "20.3 g",
         "fat": "37.1 g",
         "carbs": "25.5 g"
+      }
+    },
+    {
+      "name": "Nachogratäng med majs",
+      "url": "https://www.ica.se/recept/nachogratang-med-majs-729750/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_250117/cf_259/nachogratang_med_majs.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 6,
+      "match_percentage": 46.2,
+      "matched_ingredients": [
+        {
+          "ingredient": "blandfärs",
+          "deal_name": "Blandfärs",
+          "deal_price": "85:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "106,25",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "taco kryddmix",
+          "deal_name": "Pulled beef taco",
+          "deal_price": "62.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "170,00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "mild chunky salsa",
+          "deal_name": "Mild kvarg/Grekisk Yoghurt",
+          "deal_price": "35:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "48:95-52:00",
+          "jfr_pris": "35:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven prästost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris eller annat gryn",
+        "olja",
+        "vatten",
+        "salt",
+        "peppar",
+        "nachochips",
+        "krispsallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 70,
+      "nutrition": {
+        "calories": "958 calories",
+        "protein": "43 g",
+        "fat": "52 g",
+        "carbs": "78 g"
       }
     },
     {
@@ -31129,273 +33903,363 @@
       }
     },
     {
-      "name": "Taco bowl",
-      "url": "https://www.ica.se/recept/taco-bowl-729345/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243339/cf_259/taco_bowl.jpg",
+      "name": "Bakad potatis med majsröra och coleslaw",
+      "url": "https://www.ica.se/recept/bakad-potatis-med-majsrora-och-coleslaw-729241/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_244487/cf_259/bakad_potatis_med_majsrora_och_coleslaw.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 13,
       "matched_count": 6,
       "match_percentage": 46.2,
       "matched_ingredients": [
         {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
+          "ingredient": "ugns- och bakpotatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
         },
         {
-          "ingredient": "kycklingfilé",
-          "deal_name": "Färsk kycklingfilé",
-          "deal_price": "119:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "179:00",
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
           "jfr_pris": null,
           "match_score": 1.0
         },
         {
-          "ingredient": "kryddmix chili & lime taco",
-          "deal_name": "Pulled beef taco",
-          "deal_price": "62.90:-",
-          "deal_store": "ICA Kvantum",
+          "ingredient": "havrebaserad fraiche med paprika & chili",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "havrebaserad fraiche med paprika & chili",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "färgmixade småtomater",
+          "deal_name": "FÄRGMIXADE SMÅTOMATER",
+          "deal_price": "25:-",
+          "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "170,00",
-          "match_score": 0.75
-        },
+          "jfr_pris": "71,43",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyfta",
+        "färsk gräslök",
+        "salt",
+        "peppar",
+        "kål- och morotsmix",
+        "majonnäs",
+        "hjärtsallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 6,
+      "nutrition": {
+        "calories": "551 calories",
+        "protein": "11 g",
+        "fat": "24 g",
+        "carbs": "66 g"
+      }
+    },
+    {
+      "name": "Pasta med broccoli, purjolök och sardeller",
+      "url": "https://www.ica.se/recept/pasta-med-broccoli-purjolok-och-sardeller-728576/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233107/cf_259/pasta_med_broccoli__purjolok_och_sardeller.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 6,
+      "match_percentage": 46.2,
+      "matched_ingredients": [
         {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 0.9
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
         },
         {
-          "ingredient": "fryst tärnad mango",
-          "deal_name": "Mango",
+          "ingredient": "stor purjolök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
           "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "riven parmesan",
+          "deal_name": "Parmesanost",
+          "deal_price": "45:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "45,45",
+          "jfr_pris": "300",
           "match_score": 0.9
         },
         {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
+          "ingredient": "hackade valnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "ris",
-        "majskorn",
-        "srirachasås",
+        "-  1 röd peppar",
+        "sardellfiléer",
         "salt",
+        "svartpeppar",
+        "finrivet citronskal",
+        "färsk oregano",
+        "ev skivad  chili"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Pasta med broccoli, purjolök och sardeller",
+      "url": "https://www.ica.se/recept/pasta-med-broccoli-purjolok-och-sardeller-728576/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233107/cf_259/pasta_med_broccoli__purjolok_och_sardeller.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 6,
+      "match_percentage": 46.2,
+      "matched_ingredients": [
+        {
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "stor purjolök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "riven parmesan",
+          "deal_name": "Parmesanost",
+          "deal_price": "45:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "300",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "hackade valnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "-  1 röd peppar",
+        "sardellfiléer",
+        "salt",
+        "svartpeppar",
+        "finrivet citronskal",
+        "färsk oregano",
+        "ev skivad  chili"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
+      "name": "Fläskytterfilé med svampsås",
+      "url": "https://www.ica.se/recept/flaskytterfile-med-svampsas-728358/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233177/cf_259/flaskytterfilé_med_svampsas.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 6,
+      "match_percentage": 46.2,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färska champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fläskytterfilé",
+          "deal_name": "Fläskytterfilé",
+          "deal_price": null,
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "115:00",
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "babyplommontomater",
+          "deal_name": "Babyplommontomater i ask",
+          "deal_price": "25:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "38:90",
+          "jfr_pris": "50:00",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
         "olja",
-        "snackgurkor",
-        "kruka koriander"
+        "salt",
+        "peppar",
+        "mjölk",
+        "tomatpuré",
+        "japansk soja",
+        "dijonsenap"
       ],
       "time": "PT45M",
       "servings": "4",
       "rating": 4.6,
-      "reviews": 16,
+      "reviews": 13,
       "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
-      "name": "Pasta med broccoli, purjolök och sardeller",
-      "url": "https://www.ica.se/recept/pasta-med-broccoli-purjolok-och-sardeller-728576/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233107/cf_259/pasta_med_broccoli__purjolok_och_sardeller.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 6,
-      "match_percentage": 46.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "stor purjolök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "riven parmesan",
-          "deal_name": "Parmesanost",
-          "deal_price": "45:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "300",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "hackade valnötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "-  1 röd peppar",
-        "sardellfiléer",
-        "salt",
-        "svartpeppar",
-        "finrivet citronskal",
-        "färsk oregano",
-        "ev skivad  chili"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
-      "name": "Pasta med broccoli, purjolök och sardeller",
-      "url": "https://www.ica.se/recept/pasta-med-broccoli-purjolok-och-sardeller-728576/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233107/cf_259/pasta_med_broccoli__purjolok_och_sardeller.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 6,
-      "match_percentage": 46.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "stor purjolök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "riven parmesan",
-          "deal_name": "Parmesanost",
-          "deal_price": "45:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "300",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "hackade valnötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "-  1 röd peppar",
-        "sardellfiléer",
-        "salt",
-        "svartpeppar",
-        "finrivet citronskal",
-        "färsk oregano",
-        "ev skivad  chili"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
+        "calories": "683 calories",
+        "protein": "42 g",
+        "fat": "36 g",
+        "carbs": "43 g"
       }
     },
     {
@@ -31549,12 +34413,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -31730,11 +34594,11 @@
         {
           "ingredient": "riven gratängost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -31846,6 +34710,96 @@
         "protein": "5 g",
         "fat": "21 g",
         "carbs": "10 g"
+      }
+    },
+    {
+      "name": "Krämig pasta med kycklinglårfilé och basilika",
+      "url": "https://www.ica.se/recept/kramig-pasta-med-kycklinglarfile-och-basilika-724491/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_188185/cf_259/kramig_pasta_med_kycklinglarfilé_och_basilika.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 6,
+      "match_percentage": 46.2,
+      "matched_ingredients": [
+        {
+          "ingredient": "tagliatelle",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kycklinglårfilé",
+          "deal_name": "Kycklinglårfilé",
+          "deal_price": "79.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,97",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "strimlade soltorkade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "vitlöksklyfta",
+        "mjölk",
+        "kruka basilika",
+        "tomatmix"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 23,
+      "nutrition": {
+        "calories": "784 calories",
+        "protein": "43 g",
+        "fat": "38 g",
+        "carbs": "63 g"
       }
     },
     {
@@ -32180,11 +35134,11 @@
         {
           "ingredient": "riven gratängost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -32449,12 +35403,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -32809,12 +35763,12 @@
         },
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -33072,12 +36026,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -33110,97 +36064,6 @@
         "protein": "15 g",
         "fat": "33 g",
         "carbs": "42 g"
-      }
-    },
-    {
-      "name": "Kycklingsnitzel med ljummen potatissallad",
-      "url": "https://www.ica.se/recept/kycklingsnitzel-med-ljummen-potatissallad-729208/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243317/cf_259/kycklingsnitzel_med_ljummen_potatissallad.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 6,
-      "match_percentage": 42.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vetemjöl",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "kapris",
-        "smetana",
-        "curry",
-        "snabbfiléer av kyckling",
-        "salt",
-        "peppar",
-        "olja",
-        "rödgrön kruksallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.9,
-      "reviews": 7,
-      "nutrition": {
-        "calories": "727 calories",
-        "protein": "45 g",
-        "fat": "34 g",
-        "carbs": "55 g"
       }
     },
     {
@@ -33265,7 +36128,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -33386,6 +36249,97 @@
       }
     },
     {
+      "name": "Pastasallad med kyckling",
+      "url": "https://www.ica.se/recept/pastasallad-med-kyckling-729700/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248534/cf_259/pastasallad_med_kyckling.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 6,
+      "match_percentage": 42.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "hel grillad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "lagrad ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "körsbärstomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "gul eller röd paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "rädisor",
+        "kalamataoliver",
+        "basilikapesto",
+        "rödvinsvinäger",
+        "olivolja",
+        "salt",
+        "svartpeppar",
+        "rucola"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 40,
+      "nutrition": {
+        "calories": "949 calories",
+        "protein": "57 g",
+        "fat": "55 g",
+        "carbs": "54 g"
+      }
+    },
+    {
       "name": "Halloumigryta med aubergine och couscous",
       "url": "https://www.ica.se/recept/halloumigryta-med-aubergine-och-couscous-724335/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233630/cf_259/halloumigryta_med_aubergine_och_couscous.jpg",
@@ -33447,11 +36401,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -33750,6 +36704,97 @@
       }
     },
     {
+      "name": "Minutfilé med rostad potatis och morotssallad",
+      "url": "https://www.ica.se/recept/minutfile-med-rostad-potatis-och-morotssallad-725590/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_198188/cf_259/minutfilé_med_rostad_potatis_och_morotssallad.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 6,
+      "match_percentage": 42.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "morötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "kyld sås",
+          "deal_name": "KYLD SÅS, DRESSING",
+          "deal_price": "35:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "persilja",
+          "deal_name": "BLADPERSILJA 250G",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "79,60",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ca 2 msk olivolja",
+        "salt",
+        "vitpeppar",
+        "- ca 1 msk olivolja",
+        "vinäger",
+        "skalet av 1 citron",
+        "svartpeppar",
+        "olja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 14,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
+      }
+    },
+    {
       "name": "Vegobitar fajitas med rostad pumpa och tzatziki",
       "url": "https://www.ica.se/recept/vegobitar-fajitas-med-rostad-pumpa-och-tzatziki-720717/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_141012/cf_259/vegobitar_fajitas_med_rostad_pumpa_och_tzatziki.jpg",
@@ -33801,7 +36846,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -34020,6 +37065,97 @@
         "protein": "20 g",
         "fat": "38 g",
         "carbs": "28 g"
+      }
+    },
+    {
+      "name": "Kyckling chili",
+      "url": "https://www.ica.se/recept/kyckling-chili-721063/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_164399/cf_259/kyckling_chili.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 6,
+      "match_percentage": 42.9,
+      "matched_ingredients": [
+        {
+          "ingredient": "pulled chicken",
+          "deal_name": "PULLED PORK",
+          "deal_price": "39.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "72,55",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "krossade tomater",
+          "deal_name": "Krossade tomater",
+          "deal_price": "30:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "37,50",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "mild chunky salsa",
+          "deal_name": "Mild kvarg/Grekisk Yoghurt",
+          "deal_price": "35:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "48:95-52:00",
+          "jfr_pris": "35:00",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "riven ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gräddfil",
+          "deal_name": "Gräddfil",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyfta",
+        "av bbq-sås",
+        "oregano",
+        "chiliflakes",
+        "vatten",
+        "bönmix",
+        "salt",
+        "nachochips"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -34248,11 +37384,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -34360,11 +37496,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -34514,11 +37650,11 @@
         {
           "ingredient": "ostronskivling",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -34585,13 +37721,13 @@
       "matched_ingredients": [
         {
           "ingredient": "ca 150 g bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "ca 400 g kycklinglårfilé",
@@ -34727,13 +37863,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -35032,98 +38168,6 @@
         "protein": "17 g",
         "fat": "33 g",
         "carbs": "66 g"
-      }
-    },
-    {
-      "name": "Kalkon i ugn med äpple och gräddsås",
-      "url": "https://www.ica.se/recept/kalkon-i-ugn-med-apple-och-graddsas-726192/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/bf7a43ibu3ry3miuup9t.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 6,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "äpplen",
-          "deal_name": "Svenska äpplen",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "31:90-36:90",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "krossade vitlöksklyftor",
-          "deal_name": "Krossade tomater",
-          "deal_price": "30:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "37,50",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "hel kalkon",
-          "deal_name": "Kalkonköttbullar/Kalkonfärs",
-          "deal_price": "57.90:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "144,75",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "konc kalvfond",
-          "deal_name": "Fond",
-          "deal_price": "60:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "41:90",
-          "jfr_pris": "7:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "japansk soja",
-        "salt",
-        "hackad färsk rosmarin",
-        "salt",
-        "ca 4 dl sky från kalkon",
-        "ev 1 tsk majsstärkelse",
-        "-  4 msk äppelmos",
-        "salt",
-        "svartpeppar"
-      ],
-      "time": "PT90M",
-      "servings": "8-10",
-      "rating": 4.7,
-      "reviews": 117,
-      "nutrition": {
-        "calories": "896 calories",
-        "protein": "107 g",
-        "fat": "46 g",
-        "carbs": "13 g"
       }
     },
     {
@@ -35519,7 +38563,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -35536,27 +38580,27 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "varmrökt lax",
           "deal_name": "VARMRÖKT REGNBÅGSLAX",
-          "deal_price": "Medlemspris",
+          "deal_price": "119:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -35638,7 +38682,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -35801,13 +38845,13 @@
         },
         {
           "ingredient": "skivad bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "färska jordgubbar",
@@ -35831,12 +38875,12 @@
         },
         {
           "ingredient": "hackade rostade pekannötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -36078,11 +39122,11 @@
         {
           "ingredient": "getost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -36098,7 +39142,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -36139,98 +39183,6 @@
       }
     },
     {
-      "name": "Het pasta med torrsaltat bacon och majs",
-      "url": "https://www.ica.se/recept/het-pasta-med-torrsaltat-bacon-och-majs-723235/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_174176/cf_259/het_pasta_med_torrsaltat_bacon_och_majs.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 6,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "torrsaltat bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "soltorkade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "majskorn",
-        "olja",
-        "röd peppar",
-        "vitlöksklyfta",
-        "mjölk",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "färsk gräslök eller persilja"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 28,
-      "nutrition": {
-        "calories": "738 calories",
-        "protein": "27 g",
-        "fat": "36 g",
-        "carbs": "72 g"
-      }
-    },
-    {
       "name": "Poké bowl",
       "url": "https://www.ica.se/recept/poke-bowl-720870/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_250266/cf_259/poké_bowl.jpg",
@@ -36241,12 +39193,12 @@
       "matched_ingredients": [
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -36282,7 +39234,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -36363,12 +39315,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -36412,98 +39364,6 @@
         "protein": "10 g",
         "fat": "23 g",
         "carbs": "40 g"
-      }
-    },
-    {
-      "name": "Pulled beans i tortillabröd cheddarkräm",
-      "url": "https://www.ica.se/recept/pulled-beans-i-tortillabrod-cheddarkram-726302/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210514/cf_259/pulled_beans_i_tortillabrod_cheddarkram.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 6,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vetemjöl",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "pulled beans",
-          "deal_name": "PULLED PORK",
-          "deal_price": "39.90:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "72,55",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "små mjuka tortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "avrunnen inlagd jalapeño",
-        "majskorn",
-        "mjölk",
-        "salt",
-        "svartpeppar",
-        "silverlök",
-        "kruka krispsallad",
-        "spiskummin",
-        "ev färsk koriander"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.9,
-      "reviews": 15,
-      "nutrition": {
-        "calories": "444 calories",
-        "protein": "19 g",
-        "fat": "21 g",
-        "carbs": "43 g"
       }
     },
     {
@@ -36731,12 +39591,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -36814,11 +39674,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -36827,7 +39687,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -36926,12 +39786,12 @@
         },
         {
           "ingredient": "skivor cheddar eller annan lagrad ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -36969,96 +39829,96 @@
       }
     },
     {
-      "name": "Sötpotatis texmex",
-      "url": "https://www.ica.se/recept/sotpotatis-texmex-729303/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243345/cf_259/sotpotatis_texmex___.jpg",
+      "name": "Krämig gryta med kyckling och mango chutney",
+      "url": "https://www.ica.se/recept/kramig-gryta-med-kyckling-och-mango-chutney-728471/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234348/cf_259/kramig_kycklinggryta_med_mango_chutney_.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 16,
       "matched_count": 6,
       "match_percentage": 37.5,
       "matched_ingredients": [
         {
-          "ingredient": "sötpotatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
+          "ingredient": "honung",
+          "deal_name": "Blomsterhonung",
+          "deal_price": "55:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "55",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kycklingbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
           "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
         },
         {
-          "ingredient": "salladslök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
+          "ingredient": "mango chutney",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
+          "jfr_pris": "45,45",
           "match_score": 0.9
         },
         {
-          "ingredient": "miniplommontomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "olivolja",
+        "ca 400 g rödkål",
+        "rödvinsvinäger",
         "salt",
+        "olja",
         "peppar",
-        "kokta svarta bönor",
-        "majskorn",
-        "olivolja",
-        "chiliflakes",
-        "kruka koriander",
-        "lime",
-        "cosmopolitansallad"
+        "ris eller annat gryn",
+        "olja",
+        "curry",
+        "mjölk",
+        "färsk gräslök"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 15,
+      "rating": 4.6,
+      "reviews": 110,
       "nutrition": {
-        "calories": "887 calories",
-        "protein": "19 g",
-        "fat": "44 g",
-        "carbs": "97 g"
+        "calories": "722 calories",
+        "protein": "43 g",
+        "fat": "32 g",
+        "carbs": "64 g"
       }
     },
     {
@@ -37113,7 +39973,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -37362,7 +40222,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -37401,12 +40261,12 @@
         },
         {
           "ingredient": "rostade sesamfrö",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -37538,11 +40398,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -37620,6 +40480,99 @@
       }
     },
     {
+      "name": "Fläskytterfilé med gräddsås och pressgurka",
+      "url": "https://www.ica.se/recept/flaskytterfile-med-graddsas-och-pressgurka-728474/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234608/cf_259/flaskytterfilé_med_graddsas_och_pressgurka.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 16,
+      "matched_count": 6,
+      "match_percentage": 37.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "färsk persilja",
+          "deal_name": "BLADPERSILJA 250G",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "79,60",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fläskytterfilé",
+          "deal_name": "Fläskytterfilé",
+          "deal_price": null,
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "115:00",
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "köttbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölig potatis",
+        "mjölk",
+        "salt",
+        "peppar",
+        "ättiksprit",
+        "strösocker",
+        "salt",
+        "vatten",
+        "olja",
+        "mjölk"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 16,
+      "nutrition": {
+        "calories": "603 calories",
+        "protein": "44 g",
+        "fat": "23 g",
+        "carbs": "54 g"
+      }
+    },
+    {
       "name": "Halloumitikka masala med paprikasallad",
       "url": "https://www.ica.se/recept/halloumitikka-masala-med-paprikasallad-727798/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_227672/cf_259/halloumitikka_masala_med_paprikasallad_.jpg",
@@ -37631,11 +40584,11 @@
         {
           "ingredient": "grillost eller halloumi",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -37724,11 +40677,11 @@
         {
           "ingredient": "grillost eller halloumi",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -37803,6 +40756,285 @@
         "protein": "30 g",
         "fat": "41 g",
         "carbs": "69 g"
+      }
+    },
+    {
+      "name": "Rödbetor med rostade vindruvor och minutbiff",
+      "url": "https://www.ica.se/recept/rodbetor-med-rostade-vindruvor-och-minutbiff-727192/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218620/cf_259/rodbetor_med_rostade_vindruvor_och_minutbiff.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 16,
+      "matched_count": 6,
+      "match_percentage": 37.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödbetor",
+          "deal_name": "Rödbetor",
+          "deal_price": "12:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "12",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "valnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röda kärnfria vindruvor",
+          "deal_name": "Röda kärnfria druvor i ask",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutbiff",
+          "deal_name": "Färsk biff",
+          "deal_price": "59.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "332,78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse sallad",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "salt",
+        "olivolja",
+        "äppelcidervinäger",
+        "dijonsenap",
+        "salt",
+        "svartpeppar",
+        "salt",
+        "svartpeppar",
+        "ca 200 g chèvre"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 12,
+      "nutrition": {
+        "calories": "712 calories",
+        "protein": "47 g",
+        "fat": "44 g",
+        "carbs": "28 g"
+      }
+    },
+    {
+      "name": "Rödbetor med rostade vindruvor och minutbiff",
+      "url": "https://www.ica.se/recept/rodbetor-med-rostade-vindruvor-och-minutbiff-727192/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218620/cf_259/rodbetor_med_rostade_vindruvor_och_minutbiff.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 16,
+      "matched_count": 6,
+      "match_percentage": 37.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "rödbetor",
+          "deal_name": "Rödbetor",
+          "deal_price": "12:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "12",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "valnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "röda kärnfria vindruvor",
+          "deal_name": "Röda kärnfria druvor i ask",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "ca 600 g minutbiff",
+          "deal_name": "Färsk biff",
+          "deal_price": "59.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "332,78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse sallad",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "salt",
+        "olivolja",
+        "äppelcidervinäger",
+        "dijonsenap",
+        "salt",
+        "svartpeppar",
+        "salt",
+        "svartpeppar",
+        "ca 200 g chèvre"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 12,
+      "nutrition": {
+        "calories": "712 calories",
+        "protein": "47 g",
+        "fat": "44 g",
+        "carbs": "28 g"
+      }
+    },
+    {
+      "name": "Krämig kycklinggryta med fänkål och timjan",
+      "url": "https://www.ica.se/recept/kramig-kycklinggryta-med-fankal-och-timjan-724546/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192253/cf_259/kramig_kycklinggryta_med_fankal_och_timjan.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 16,
+      "matched_count": 6,
+      "match_percentage": 37.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "kycklinglårfilé",
+          "deal_name": "Kycklinglårfilé",
+          "deal_price": "79.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,97",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kycklingbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "fänkål",
+        "olivolja",
+        "kruka timjan",
+        "salt",
+        "peppar",
+        "mjölk",
+        "citron",
+        "tomatmix",
+        "rödvinsvinäger",
+        "olivolja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 13,
+      "nutrition": {
+        "calories": "684 calories",
+        "protein": "40 g",
+        "fat": "33 g",
+        "carbs": "53 g"
       }
     },
     {
@@ -37837,7 +41069,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -37910,7 +41142,7 @@
         {
           "ingredient": "kycklingben",
           "deal_name": "KYCKLINGBEN",
-          "deal_price": "Medlemspris",
+          "deal_price": "59.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -37939,12 +41171,12 @@
         },
         {
           "ingredient": "majskolvar i bitar",
-          "deal_name": "MAJSKOLVAR",
-          "deal_price": "35:-",
-          "deal_store": "Willys",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "43,75",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
@@ -38096,7 +41328,7 @@
         {
           "ingredient": "kycklingben",
           "deal_name": "KYCKLINGBEN",
-          "deal_price": "Medlemspris",
+          "deal_price": "59.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -38125,12 +41357,12 @@
         },
         {
           "ingredient": "majskolvar i bitar",
-          "deal_name": "MAJSKOLVAR",
-          "deal_price": "35:-",
-          "deal_store": "Willys",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "43,75",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
@@ -38331,12 +41563,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -38416,11 +41648,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -38456,6 +41688,100 @@
         "protein": "30 g",
         "fat": "33 g",
         "carbs": "46 g"
+      }
+    },
+    {
+      "name": "Tofu med broccoli i sötsur ingefärssås",
+      "url": "https://www.ica.se/recept/tofu-med-broccoli-i-sotsur-ingefarssas-750497/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/vdoy7jk6yvsieogj1sv4.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 17,
+      "matched_count": 6,
+      "match_percentage": 35.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "majsstärkelse eller potatismjöl",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rostade sesamfrön",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "broccoli",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "rapsolja",
+          "deal_name": "Rapsolja",
+          "deal_price": "49:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "strimlad salladslök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "fast tofu",
+        "salt",
+        "riven färsk ingefära",
+        "vitlöksklyftor",
+        "japansk soja",
+        "strösocker",
+        "risvinäger",
+        "sesamolja",
+        "vatten",
+        "jasminris",
+        "sesamfrön"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 32,
+      "nutrition": {
+        "calories": "573 calories",
+        "protein": "19 g",
+        "fat": "21 g",
+        "carbs": "73 g"
       }
     },
     {
@@ -38980,11 +42306,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -39167,22 +42493,22 @@
         },
         {
           "ingredient": "majstortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "59,52",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
           "ingredient": "riven tacoost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -39223,11 +42549,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -39276,7 +42602,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -39304,101 +42630,6 @@
         "protein": "37 g",
         "fat": "52 g",
         "carbs": "52 g"
-      }
-    },
-    {
-      "name": "Pannbiff med löksås",
-      "url": "https://www.ica.se/recept/pannbiff-med-loksas-727247/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_245083/cf_259/pannbiff_med_loksas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 18,
-      "matched_count": 6,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "blandfärs eller hushållsfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smör eller olja",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "köttbuljongtärning eller motsvarande mängd fond",
-          "deal_name": "Fond",
-          "deal_price": "60:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "41:90",
-          "jfr_pris": "7:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölk",
-        "dijonsenap",
-        "salt",
-        "peppar",
-        "olja",
-        "hackad fryst eller färsk lök",
-        "mjölk",
-        "majsstärkelse",
-        "mellangrädde",
-        "japansk soja",
-        "salt",
-        "peppar"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 143,
-      "nutrition": {
-        "calories": "721 calories",
-        "protein": "34 g",
-        "fat": "40 g",
-        "carbs": "54 g"
       }
     },
     {
@@ -39453,21 +42684,21 @@
         {
           "ingredient": "roquefortost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "råkostsallad",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -39494,101 +42725,6 @@
         "protein": "42 g",
         "fat": "22 g",
         "carbs": "66 g"
-      }
-    },
-    {
-      "name": "Hemgjorda fiskbullar med ingefära och nudlar",
-      "url": "https://www.ica.se/recept/hemgjorda-fiskbullar-med-ingefara-och-nudlar-726652/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213081/cf_259/hemgjorda_fiskbullar_med_ingefara_och_nudlar.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 18,
-      "matched_count": 6,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "äggvita",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "hönsbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vit misopasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ramennudlar",
-          "deal_name": "NUDLAR",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "213,98",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färska böngroddar",
-          "deal_name": "FÄRSKA KRYDDOR 15-25G",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "660",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "skinnfri torskfilé",
-        "salt",
-        "majsstärkelse",
-        "hackad chilifrukt",
-        "finriven  ingefära",
-        "finrivet limeskal",
-        "finriven vitlöksklyfta",
-        "hackad koriander",
-        "vatten",
-        "sambal oelek",
-        "pak choi",
-        "färsk koriander"
-      ],
-      "time": "PT60M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 10,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -39653,7 +42789,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -39687,101 +42823,6 @@
       }
     },
     {
-      "name": "Hemgjorda fiskbullar med ingefära och nudlar",
-      "url": "https://www.ica.se/recept/hemgjorda-fiskbullar-med-ingefara-och-nudlar-726652/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_213081/cf_259/hemgjorda_fiskbullar_med_ingefara_och_nudlar.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 18,
-      "matched_count": 6,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "äggvita",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "hönsbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vit misopasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ramennudlar",
-          "deal_name": "NUDLAR",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "213,98",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färska böngroddar",
-          "deal_name": "FÄRSKA KRYDDOR 15-25G",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "660",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "skinnfri torskfilé",
-        "salt",
-        "majsstärkelse",
-        "hackad chilifrukt",
-        "finriven  ingefära",
-        "finrivet limeskal",
-        "finriven vitlöksklyfta",
-        "hackad koriander",
-        "vatten",
-        "sambal oelek",
-        "pak choi",
-        "färsk koriander"
-      ],
-      "time": "PT60M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 10,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
       "name": "Italiensk Delizie med skinka och basilika",
       "url": "https://www.ica.se/recept/italiensk-delizie-med-skinka-och-basilika-714951/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_63530/cf_259/italiensk_delizie_med_skinka_och_basilika.jpg",
@@ -39843,7 +42884,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -40388,11 +43429,11 @@
         {
           "ingredient": "hackad inlagd gurka eller bostongurka",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -40454,103 +43495,6 @@
       }
     },
     {
-      "name": "Färsbiffar med rostad pumpa och spenat",
-      "url": "https://www.ica.se/recept/farsbiffar-med-rostad-pumpa-och-spenat-729096/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241658/cf_259/farsbiffar_med_rostad_pumpa_och_spenat.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 20,
-      "matched_count": 6,
-      "match_percentage": 30.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödlökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "honung",
-          "deal_name": "Blomsterhonung",
-          "deal_price": "55:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "55",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "hokkaido pumpa",
-        "olja",
-        "salt",
-        "peppar",
-        "babyspenat",
-        "salt",
-        "senap",
-        "peppar",
-        "mjölk",
-        "olja",
-        "mjölk",
-        "majsstärkelse",
-        "torkad timjan",
-        "japansk soja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "715 calories",
-        "protein": "35 g",
-        "fat": "36 g",
-        "carbs": "58 g"
-      }
-    },
-    {
       "name": "Torsk med ostronsmörsås, krispigt ris och syrlig gurka",
       "url": "https://www.ica.se/recept/torsk-med-ostronsmorsas-krispigt-ris-och-syrlig-gurka-750201/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/ffvxj0ou8ypv9r4thf7g.jpg",
@@ -40572,7 +43516,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -40592,11 +43536,11 @@
         {
           "ingredient": "ostron",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -40903,13 +43847,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -40938,104 +43882,6 @@
         "protein": "38 g",
         "fat": "60 g",
         "carbs": "44 g"
-      }
-    },
-    {
-      "name": "Quinoaburgare med sötpotatisfrites",
-      "url": "https://www.ica.se/recept/quinoaburgare-med-sotpotatisfrites-721451/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_152893/cf_259/quinoaburgare_med_sotpotatisfrites.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 21,
-      "matched_count": 6,
-      "match_percentage": 28.6,
-      "matched_ingredients": [
-        {
-          "ingredient": "sötpotatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "yoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "cm strimlad purjolök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "hackad persilja",
-          "deal_name": "BLADPERSILJA 250G",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "79,60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "hamburgerbröd",
-          "deal_name": "Hamburgerbröd",
-          "deal_price": "15:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "tomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "mix till quinoaburgare",
-        "majsstärkelse",
-        "olivolja",
-        "havssalt",
-        "svartpeppar",
-        "majonnäs",
-        "dijonsenap",
-        "örtsalt",
-        "tabasco",
-        "ca 150 g strimlad rödbeta",
-        "ca 300 g strimlad rödkål",
-        "salladsblad",
-        "picklad lök",
-        "majonnäs",
-        "chilisås eller ketchup"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -41158,7 +44004,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -41286,13 +44132,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "hamburgerbröd",
@@ -41332,106 +44178,6 @@
         "protein": "22 g",
         "fat": "55 g",
         "carbs": "95 g"
-      }
-    },
-    {
-      "name": "Fiskgratäng med hummer",
-      "url": "https://www.ica.se/recept/fiskgratang-med-hummer-729620/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_245757/cf_259/fiskgratang_med_hummer.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 23,
-      "matched_count": 6,
-      "match_percentage": 26.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "färskpressad citronjuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "äggulor",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "kokta humrar",
-        "vitlöksklyfta",
-        "timjankvistar",
-        "tomatpuré",
-        "vitt vin",
-        "vatten",
-        "-  2 msk majsstärkelse",
-        "salt",
-        "mjölig potatis",
-        "finrivet citronskal",
-        "svartpeppar",
-        "torskfilé",
-        "salt",
-        "fänkål",
-        "olja",
-        "färsk bladspenat",
-        "plockad dill"
-      ],
-      "time": "PT90M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 18,
-      "nutrition": {
-        "calories": "1197 calories",
-        "protein": "61 g",
-        "fat": "74 g",
-        "carbs": "55 g"
       }
     },
     {
@@ -41495,12 +44241,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -41612,6 +44358,80 @@
       }
     },
     {
+      "name": "Paprikagratinerad kassler med tomat",
+      "url": "https://www.ica.se/recept/paprikagratinerad-kassler-med-tomat-725044/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195910/cf_259/paprikagratinerad_kassler_med_tomat.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 6,
+      "matched_count": 5,
+      "match_percentage": 83.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 600 g kassler",
+          "deal_name": "Kassler (Sverige/Scan)",
+          "deal_price": "99:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "kg",
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "pestopaprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "påse riven  ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "körsbärstomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris eller annat gryn"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 17,
+      "nutrition": {
+        "calories": "750 calories",
+        "protein": "43 g",
+        "fat": "40 g",
+        "carbs": "52 g"
+      }
+    },
+    {
       "name": "Vit pinsa med crème fraiche, folkeost och valnötter",
       "url": "https://www.ica.se/recept/vit-pinsamed-creme-fraiche-folkeost-och-valnotter-740440/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/vvfcpbu7wihir76hajx8.jpg",
@@ -41663,11 +44483,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -41738,11 +44558,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -42334,7 +45154,7 @@
         {
           "ingredient": "buffelmozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -42390,12 +45210,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -42411,7 +45231,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -42478,11 +45298,11 @@
         {
           "ingredient": "brieost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -42521,83 +45341,6 @@
         "protein": "13 g",
         "fat": "28 g",
         "carbs": "28 g"
-      }
-    },
-    {
-      "name": "Tacosoppa",
-      "url": "https://www.ica.se/recept/tacosoppa-725665/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202133/cf_259/tacosoppa.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 9,
-      "matched_count": 5,
-      "match_percentage": 55.6,
-      "matched_ingredients": [
-        {
-          "ingredient": "nötfärs",
-          "deal_name": "Umamifärs",
-          "deal_price": null,
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "54:90",
-          "jfr_pris": "79:80",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "bakpotatisar",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "taco kryddmix",
-          "deal_name": "Pulled beef taco",
-          "deal_price": "62.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "170,00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "passerade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "köttbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "majskorn",
-        "nachochips",
-        "olja",
-        "vatten"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 158,
-      "nutrition": {
-        "calories": "591 calories",
-        "protein": "41 g",
-        "fat": "24 g",
-        "carbs": "49 g"
       }
     },
     {
@@ -42776,11 +45519,11 @@
         {
           "ingredient": "riven prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -42853,11 +45596,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -42920,11 +45663,11 @@
         {
           "ingredient": "färskriven parmesan eller annan lagrad hårdost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -43063,84 +45806,6 @@
       }
     },
     {
-      "name": "Enchiladas med vegofärs",
-      "url": "https://www.ica.se/recept/enchiladas-med-vegofars-730395/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/swz1w0go5r35b8c0hhgg.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 10,
-      "matched_count": 5,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "passerade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "stacky´s smartare färs eller annan vegofärs",
-          "deal_name": "Färsk Vego",
-          "deal_price": "60:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "100",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "kryddmix enchilada",
-        "vatten",
-        "isbergssalladshuvud",
-        "majskorn"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 10,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
       "name": "Kvargpannkakor med varma bär",
       "url": "https://www.ica.se/recept/kvargpannkakor-med-varma-bar-740401/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/cap2jftscitobtedrq3d.jpg",
@@ -43216,6 +45881,84 @@
         "protein": "7 g",
         "fat": "3 g",
         "carbs": "11 g"
+      }
+    },
+    {
+      "name": "Krispiga smashed potatoes",
+      "url": "https://www.ica.se/recept/krispiga-smashed-potatoes-722468/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_168736/cf_259/smashed_potatoes_med_ortsmor_.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 10,
+      "matched_count": 5,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "amadine potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "panko eller vanligt ströbröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grillad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "röd mangold",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olivolja",
+        "rosmarin",
+        "timjan",
+        "flingsalt",
+        "nymald svartpeppar"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 141,
+      "nutrition": {
+        "calories": "527 calories",
+        "protein": "34 g",
+        "fat": "24 g",
+        "carbs": "41 g"
       }
     },
     {
@@ -43406,7 +46149,7 @@
         {
           "ingredient": "kycklingben",
           "deal_name": "KYCKLINGBEN",
-          "deal_price": "Medlemspris",
+          "deal_price": "59.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -43416,7 +46159,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -43503,12 +46246,12 @@
         },
         {
           "ingredient": "rostade kokoschips",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -43551,22 +46294,22 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -43609,6 +46352,84 @@
       }
     },
     {
+      "name": "Krämig pasta med pesto och bacon",
+      "url": "https://www.ica.se/recept/kramig-pasta-med-pesto-och-bacon-724880/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_190999/cf_259/kramig_pasta_med_pesto_och_bacon.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 10,
+      "matched_count": 5,
+      "match_percentage": 50.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "bacon",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "champinjoner",
+          "deal_name": "Champinjoner",
+          "deal_price": "30:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "60",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "mjölk",
+        "basilika pesto",
+        "svartpeppar",
+        "ev salt"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 25,
+      "nutrition": {
+        "calories": "684 calories",
+        "protein": "26 g",
+        "fat": "38 g",
+        "carbs": "58 g"
+      }
+    },
+    {
       "name": "Tonfisk med calabrese",
       "url": "https://www.ica.se/recept/tonfisk-med-calabrese-726865/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_217865/cf_259/tonfisk_med_calabrese__.jpg",
@@ -43629,22 +46450,22 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -43765,84 +46586,6 @@
       }
     },
     {
-      "name": "Snabb torskgryta med morötter",
-      "url": "https://www.ica.se/recept/snabb-torskgryta-med-morotter-726260/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_212592/cf_259/snabb_torskgryta_med_morotter.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 10,
-      "matched_count": 5,
-      "match_percentage": 50.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "påse morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "förp  soppa",
-          "deal_name": "KYLD SOPPA",
-          "deal_price": "48:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "fiskbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "torskfilé",
-        "olja",
-        "majsstärkelse",
-        "salt",
-        "peppar"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 11,
-      "nutrition": {
-        "calories": "492 calories",
-        "protein": "37 g",
-        "fat": "14 g",
-        "carbs": "49 g"
-      }
-    },
-    {
       "name": "Ugnspannkaka med äpple, grönkål och bacon",
       "url": "https://www.ica.se/recept/ugnspannkaka-med-apple-gronkal-och-bacon-722045/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_160840/cf_259/ugnspannkaka_med_apple__gronkal_och_bacon.jpg",
@@ -43863,13 +46606,13 @@
         },
         {
           "ingredient": "klippt bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "rapsolja",
@@ -43972,11 +46715,11 @@
         {
           "ingredient": "lagrad riven ost t ex grevé",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -44019,13 +46762,13 @@
         },
         {
           "ingredient": "tärnat bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "matlagningsgrädde",
@@ -44099,7 +46842,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -44188,11 +46931,11 @@
         {
           "ingredient": "kycklingbröstfiléer",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -44394,85 +47137,6 @@
       }
     },
     {
-      "name": "Sallad med ugnsrostade rödbetor, kyckling och fetaost",
-      "url": "https://www.ica.se/recept/sallad-med-ugnsrostade-rodbetor-kyckling-och-fetaost-725868/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202462/cf_259/sallad_med_ugnsrostade_rodbetor__kyckling_och_fetaost.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 5,
-      "match_percentage": 45.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "sats ugnsrostade rödbetor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kokt matvete",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "yoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse blandsallad",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "sats pocherad kyckling",
-        "sats frömix",
-        "kruka basilika",
-        "olivolja",
-        "salt",
-        "svartpeppar"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
       "name": "Basilikagratinerad torsk",
       "url": "https://www.ica.se/recept/basilikagratinerad-torsk-727982/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_230738/cf_259/basilikagratinerad_torsk__.jpg",
@@ -44504,11 +47168,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -44573,11 +47237,11 @@
         {
           "ingredient": "riven pecorinoost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -44603,11 +47267,11 @@
         {
           "ingredient": "riven pecorinoost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -44710,9 +47374,9 @@
       }
     },
     {
-      "name": "Fläsknoisetter med rostad majs och vitlöksdipp",
-      "url": "https://www.ica.se/recept/flasknoisetter-med-rostad-majs-och-vitloksdipp-726164/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_211547/cf_259/flasknoisetter_med_rostad_majs_och_vitloksdipp.jpg",
+      "name": "Kycklingfilé med klyftpotatis och fänkålssallad",
+      "url": "https://www.ica.se/recept/kycklingfile-med-klyftpotatis-och-fankalssallad-727559/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_226001/cf_259/kycklingfilé_med_klyftpotatis_och_fankalssallad.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 5,
@@ -44729,63 +47393,63 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "paprikapulver",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ca 500 g fläskytterfilé",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
-          "ingredient": "smör",
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "smör eller olja",
           "deal_name": "Smör",
           "deal_price": "55:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
           "ord_pris": "78:00",
           "jfr_pris": "110:00",
-          "match_score": 1.0
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "äpple- och currysås",
+          "deal_name": "Svenska äpplen",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/kg",
+          "ord_pris": "31:90-36:90",
+          "jfr_pris": null,
+          "match_score": 0.85
         }
       ],
       "unmatched_ingredients": [
         "olja",
         "salt",
         "peppar",
-        "majskorn",
-        "vitlöksklyfta",
-        "romansallad"
+        "fänkål",
+        "citron",
+        "olivolja"
       ],
       "time": "PT45M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 12,
+      "reviews": 8,
       "nutrition": {
-        "calories": "602 calories",
-        "protein": "29 g",
-        "fat": "30 g",
-        "carbs": "51 g"
+        "calories": "768 calories",
+        "protein": "40 g",
+        "fat": "52 g",
+        "carbs": "33 g"
       }
     },
     {
@@ -44829,22 +47493,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "-  2 msk hackade rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -44889,11 +47553,11 @@
         {
           "ingredient": "riven pecorinoost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -44919,11 +47583,11 @@
         {
           "ingredient": "riven pecorinoost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -45136,7 +47800,7 @@
         {
           "ingredient": "buffelmozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -45176,85 +47840,6 @@
       "servings": "4",
       "rating": 4.6,
       "reviews": 26,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
-      }
-    },
-    {
-      "name": "Toast med lammfärsbiffar och chèvre",
-      "url": "https://www.ica.se/recept/toast-med-lammfarsbiffar-och-chevre-725331/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248285/cf_259/toast_med_lammfarsbiffar_och_chèvre.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 5,
-      "match_percentage": 45.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "sats tomatsallad med rostade tomater",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ca 200 g getost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "skivor levainbröd",
-          "deal_name": "Levainbröd",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "44:90",
-          "jfr_pris": "46:15",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "blandad sallad",
-          "deal_name": "Ekologisk sallad i påse",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "230,77",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "frysta tinade sojabönor",
-          "deal_name": "Frysta Thaiboxar",
-          "deal_price": "89:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "3 för",
-          "ord_pris": "45:90",
-          "jfr_pris": "84:76-98:89",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "lammfärsbiffar",
-        "olivolja",
-        "vitvinsvinäger",
-        "dijonsenap",
-        "torkad örtkrydda",
-        "oliver"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 5,
-      "reviews": 10,
       "nutrition": {
         "calories": "",
         "protein": "",
@@ -45393,7 +47978,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -45500,6 +48085,85 @@
       }
     },
     {
+      "name": "Krämig pancettapasta",
+      "url": "https://www.ica.se/recept/kramig-pancettapasta-717575/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_93277/cf_259/kramig_pancettapasta.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 5,
+      "match_percentage": 45.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "purjolök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "spaghetti",
+          "deal_name": "SPAGHETTI",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "19,90",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rostade solroskärnor",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "bellaverde",
+        "pancetta",
+        "mjölk",
+        "salt",
+        "peppar",
+        "salladsmix"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.7,
+      "reviews": 6,
+      "nutrition": {
+        "calories": "599 calories",
+        "protein": "30.6 g",
+        "fat": "26.2 g",
+        "carbs": "56.5 g"
+      }
+    },
+    {
       "name": "Tagliatelle med kronärtskockor och salamikrisp",
       "url": "https://www.ica.se/recept/tagliatelle-med-kronartskockor-och-salamikrisp-609511/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_16906/cf_259/tagliatelle_med_kronartskockor_och_salamikrisp.jpg",
@@ -45579,82 +48243,82 @@
       }
     },
     {
-      "name": "Kyckling med brysselkål, apelsinsås och gratäng",
-      "url": "https://www.ica.se/recept/kyckling-med-brysselkal-apelsinsas-och-gratang-726069/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_208657/cf_259/apelsinkyckling_med_brysselkal_och_gratang.jpg",
+      "name": "Kycklingpasta med ärtpesto och grillad paprika",
+      "url": "https://www.ica.se/recept/kycklingpasta-med-artpesto-och-grillad-paprika-725909/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_204692/cf_259/kycklingpasta_med_artpesto_och_grillad_paprika.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 5,
       "match_percentage": 45.5,
       "matched_ingredients": [
         {
-          "ingredient": "potatisgratäng",
-          "deal_name": "POTATISGRATÄNG",
-          "deal_price": "57.90:-",
+          "ingredient": "gröna ärtor",
+          "deal_name": "GRÖNA KÄRNFRIA DRUVOR I ASK",
+          "deal_price": "25:-",
           "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "28,95",
-          "match_score": 1.0
+          "jfr_pris": "50",
+          "match_score": 0.75
         },
         {
-          "ingredient": "apelsin",
-          "deal_name": "Blodapelsiner i nät",
-          "deal_price": "20:-",
+          "ingredient": "ca 500 g kycklingfilé",
+          "deal_name": "Färsk kycklingfilé",
+          "deal_price": "119:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "36:90-39:90",
-          "jfr_pris": "20:00",
+          "deal_unit": "/kg",
+          "ord_pris": "179:00",
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
-          "ingredient": "brysselkål",
-          "deal_name": "BRYSSELKÅL I PÅSE",
-          "deal_price": "15:-",
+          "ingredient": "majsolja",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "grönsaksbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
           "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
           "match_score": 1.0
-        },
-        {
-          "ingredient": "kycklingfond",
-          "deal_name": "Fond",
-          "deal_price": "60:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "41:90",
-          "jfr_pris": "7:50",
-          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "ca 500 g tunnskivad kyckling",
+        "basilika pesto",
         "salt",
-        "grovmalen svartpeppar",
-        "majsolja",
+        "peppar",
+        "grillade paprikor",
         "vatten",
-        "kruka persilja"
+        "babyspenat"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.6,
+      "rating": 4.7,
       "reviews": 7,
       "nutrition": {
-        "calories": "581 calories",
+        "calories": "623 calories",
         "protein": "44 g",
-        "fat": "27 g",
-        "carbs": "37 g"
+        "fat": "23 g",
+        "carbs": "58 g"
       }
     },
     {
@@ -45737,16 +48401,95 @@
       }
     },
     {
-      "name": "Asiatisk kycklingsallad",
-      "url": "https://www.ica.se/recept/asiatisk-kycklingsallad-281308/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_13806/cf_259/asiatisk_kycklingsallad.jpg",
+      "name": "Rotmos med asiatiska smaker",
+      "url": "https://www.ica.se/recept/rotmos-med-asiatiska-smaker-722222/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_165095/cf_259/rotmos_med_asiatiska_smaker.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 5,
       "match_percentage": 45.5,
       "matched_ingredients": [
         {
-          "ingredient": "-  7 salladslökar",
+          "ingredient": "kålrot",
+          "deal_name": "Rotselleri, Kålrot",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "15",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "medelstora potatisar",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "brynt smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rostade sesamfrön",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "lax eller kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "morot",
+        "riven, färsk ingefära",
+        "röd chili",
+        "japansk soja",
+        "sesamolja",
+        "salt"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "445 calories",
+        "protein": "33 g",
+        "fat": "20 g",
+        "carbs": "27 g"
+      }
+    },
+    {
+      "name": "Krämig pancettapasta",
+      "url": "https://www.ica.se/recept/kramig-pancettapasta-717575/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_93277/cf_259/kramig_pancettapasta.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 11,
+      "matched_count": 5,
+      "match_percentage": 45.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "purjolök",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -45756,63 +48499,63 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "limejuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färsk mango",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "spaghetti",
+          "deal_name": "SPAGHETTI",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "45,45",
+          "jfr_pris": "19,90",
           "match_score": 1.0
         },
         {
-          "ingredient": "sallad",
-          "deal_name": "Socker- och salladsärtor i påse",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
-          "jfr_pris": "133:33",
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         },
         {
-          "ingredient": "bröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "rostade solroskärnor",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 1.0
+          "jfr_pris": "33,33",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "grillad kyckling",
-        "röd chilifrukt",
-        "kruka koriander",
-        "-  2 1/2 dl sataysås",
+        "bellaverde",
+        "pancetta",
+        "mjölk",
         "salt",
-        "peppar"
+        "peppar",
+        "salladsmix"
       ],
       "time": "PT30M",
       "servings": "4",
-      "rating": 4.9,
-      "reviews": 13,
+      "rating": 4.7,
+      "reviews": 6,
       "nutrition": {
-        "calories": "556 calories",
-        "protein": "",
-        "fat": "27.6 g",
-        "carbs": ""
+        "calories": "599 calories",
+        "protein": "30.6 g",
+        "fat": "26.2 g",
+        "carbs": "56.5 g"
       }
     },
     {
@@ -45925,22 +48668,22 @@
         },
         {
           "ingredient": "pizzakit",
-          "deal_name": "Pizzakit",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "29:95",
-          "jfr_pris": "25:00",
-          "match_score": 1.0
+          "deal_name": "PIZZAKIT, PIZZADEG",
+          "deal_price": "20:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "51,28",
+          "match_score": 0.9
         },
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -46175,12 +48918,12 @@
         },
         {
           "ingredient": "rostade rotfrukter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -46235,12 +48978,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -46375,86 +49118,6 @@
       }
     },
     {
-      "name": "Fläskytterfilé i dragonsås med pressad potatis",
-      "url": "https://www.ica.se/recept/flaskytterfile-i-dragonsas-med-pressad-potatis-729517/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246458/cf_259/flaskytterfilé_i_dragonsas_med_pressad_potatis.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 5,
-      "match_percentage": 41.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "ca 650 g fläskytterfilé",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "köttbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "majsstärkelse",
-        "mjölk",
-        "vitvinsvinäger",
-        "torkad dragon"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 60,
-      "nutrition": {
-        "calories": "641 calories",
-        "protein": "44 g",
-        "fat": "32 g",
-        "carbs": "41 g"
-      }
-    },
-    {
       "name": "Ugnsbakad fisk med bönor",
       "url": "https://www.ica.se/recept/ugnsbakad-fisk-med-bonor-729032/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241650/cf_259/ugnsbakad_fisk_med_bonor_.jpg",
@@ -46585,12 +49248,12 @@
         },
         {
           "ingredient": "furikake eller rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -46612,86 +49275,6 @@
         "protein": "8 g",
         "fat": "17 g",
         "carbs": "15 g"
-      }
-    },
-    {
-      "name": "Kyckling tikka masala med ärt- och spetskålssallad",
-      "url": "https://www.ica.se/recept/kyckling-tikka-masala-med-art-och-spetskalssallad-725405/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_199126/cf_259/kyckling_tikka_masala_med_art-_och_spetskalssallad.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 5,
-      "match_percentage": 41.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "gula lökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gröna ärtor",
-          "deal_name": "GRÖNA KÄRNFRIA DRUVOR I ASK",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "50",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "matlagningsyoghurt",
-          "deal_name": "Yoghurt",
-          "deal_price": "45:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "30:90-32:90",
-          "jfr_pris": "22:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "spetskålshuvud",
-          "deal_name": "HEL SPETSKÅL",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "19,90",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "naanbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ca 600 g minutfiléer av kyckling",
-        "olja",
-        "salt",
-        "svartpeppar",
-        "tikka masala sås",
-        "lime",
-        "ris"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "463 calories",
-        "protein": "41 g",
-        "fat": "22 g",
-        "carbs": "22 g"
       }
     },
     {
@@ -46725,13 +49308,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "färsk pasta",
@@ -46746,11 +49329,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -46815,12 +49398,12 @@
         },
         {
           "ingredient": "hel kyckling",
-          "deal_name": "Ätklara kycklingdelar",
-          "deal_price": "69:-",
+          "deal_name": "Färsk kycklingfilé",
+          "deal_price": "119:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "48:90",
-          "jfr_pris": "69:00-98:57",
+          "deal_unit": "/kg",
+          "ord_pris": "179:00",
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -47145,12 +49728,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -47255,83 +49838,83 @@
       }
     },
     {
-      "name": "Enchiladas med majs och gurka",
-      "url": "https://www.ica.se/recept/enchiladas-med-majs-och-gurka-725820/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_208320/cf_259/enchiladas_med_majs_och_gurka.jpg",
+      "name": "Stekt lax med krämig salladskål",
+      "url": "https://www.ica.se/recept/stekt-lax-med-kramig-salladskal-725552/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202888/cf_259/stekt_lax_med_kramig_salladskal.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 12,
       "matched_count": 5,
       "match_percentage": 41.7,
       "matched_ingredients": [
         {
-          "ingredient": "ca 500 g blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "delikatesspotatis",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "106,25",
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
-          "ingredient": "tortillabröd",
-          "deal_name": "Tortillabröd, Tacosås, Chips",
-          "deal_price": "100:-",
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
           "deal_store": "ICA Supermarket",
-          "deal_unit": "10 för",
-          "ord_pris": "17:50-31:90",
-          "jfr_pris": "31:25-54:05",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
           "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "laxfilé",
+          "deal_name": "Färsk laxfilé",
+          "deal_price": "149:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "149",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "påse fish taco kryddmix",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
           "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "jfr_pris": "90:00",
+          "match_score": 0.75
         }
       ],
       "unmatched_ingredients": [
-        "ris eller annat gryn",
-        "olivolja",
-        "enchilada kryddmix",
-        "tomatpuré",
-        "majskorn",
-        "vatten",
-        "chunky salsa"
+        "olja",
+        "salt",
+        "peppar",
+        "salladskål eller sommarkål",
+        "ask persilja",
+        "dijonsenap",
+        "olja"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.8,
-      "reviews": 10,
+      "rating": 4.7,
+      "reviews": 7,
       "nutrition": {
-        "calories": "937 calories",
-        "protein": "43 g",
-        "fat": "33 g",
-        "carbs": "113 g"
+        "calories": "720 calories",
+        "protein": "35 g",
+        "fat": "41 g",
+        "carbs": "48 g"
       }
     },
     {
@@ -47366,22 +49949,22 @@
         {
           "ingredient": "ca 400 g kalkonbröstfilé",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kalkonbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
+          "deal_price": "40:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
           "match_score": 0.9
+        },
+        {
+          "ingredient": "kalkonbacon",
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         },
         {
           "ingredient": "crème fraiche",
@@ -47616,7 +50199,7 @@
         {
           "ingredient": "riven mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -47626,11 +50209,11 @@
         {
           "ingredient": "riven lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -47706,12 +50289,12 @@
         },
         {
           "ingredient": "pommes frites",
-          "deal_name": "Pommes Frites, Strips",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "28:95",
-          "jfr_pris": "15:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -47767,18 +50350,18 @@
         },
         {
           "ingredient": "rostade pistagenötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -47818,84 +50401,84 @@
       }
     },
     {
-      "name": "Nachogratäng med majs",
-      "url": "https://www.ica.se/recept/nachogratang-med-majs-729750/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_250117/cf_259/nachogratang_med_majs.jpg",
+      "name": "Citronbakad lax med dillsås och hjärtsallad",
+      "url": "https://www.ica.se/recept/citronbakad-lax-med-dillsas-och-hjartsallad-729647/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248779/cf_259/citronbakad_lax_med_dillsas_och_stekt_hjartsallad .jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 13,
       "matched_count": 5,
       "match_percentage": 38.5,
       "matched_ingredients": [
         {
-          "ingredient": "blandfärs",
-          "deal_name": "Blandfärs",
-          "deal_price": "85:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "106,25",
-          "match_score": 1.0
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
         },
         {
-          "ingredient": "taco kryddmix",
-          "deal_name": "Pulled beef taco",
-          "deal_price": "62.90:-",
+          "ingredient": "laxfilé",
+          "deal_name": "Färsk laxfilé",
+          "deal_price": "149:-",
           "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "170,00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "mild chunky salsa",
-          "deal_name": "Mild kvarg/Grekisk Yoghurt",
-          "deal_price": "35:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "48:95-52:00",
-          "jfr_pris": "35:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
+          "jfr_pris": "149",
           "match_score": 1.0
         },
         {
-          "ingredient": "riven prästost",
-          "deal_name": "Riven ost",
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "skaldjurs- eller fiskbuljongtärning",
+          "deal_name": "Buljong",
           "deal_price": "30:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "ris eller annat gryn",
-        "olja",
-        "vatten",
+        "citron",
         "salt",
         "peppar",
-        "majskorn",
-        "nachochips",
-        "krispsallad"
+        "mjölk",
+        "färsk dill",
+        "hjärtsalladshuvuden",
+        "olivolja",
+        "färskpressad citronsaft"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 70,
+      "rating": 4.9,
+      "reviews": 16,
       "nutrition": {
-        "calories": "958 calories",
-        "protein": "43 g",
-        "fat": "52 g",
-        "carbs": "78 g"
+        "calories": "",
+        "protein": "",
+        "fat": "",
+        "carbs": ""
       }
     },
     {
@@ -47910,11 +50493,11 @@
         {
           "ingredient": "ostronsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -48061,87 +50644,6 @@
       }
     },
     {
-      "name": "Bakad potatis med majsröra och coleslaw",
-      "url": "https://www.ica.se/recept/bakad-potatis-med-majsrora-och-coleslaw-729241/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_244487/cf_259/bakad_potatis_med_majsrora_och_coleslaw.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 5,
-      "match_percentage": 38.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "ugns- och bakpotatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "havrebaserad fraiche med paprika & chili",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "havrebaserad fraiche med paprika & chili",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "färgmixade småtomater",
-          "deal_name": "FÄRGMIXADE SMÅTOMATER",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "71,43",
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "majskorn",
-        "vitlöksklyfta",
-        "färsk gräslök",
-        "salt",
-        "peppar",
-        "kål- och morotsmix",
-        "majonnäs",
-        "hjärtsallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "551 calories",
-        "protein": "11 g",
-        "fat": "24 g",
-        "carbs": "66 g"
-      }
-    },
-    {
       "name": "Kebab på kycklingfärs med pitabröd och paprikayoghurt",
       "url": "https://www.ica.se/recept/kebab-pa-kycklingfars-med-pitabrod-och-paprikayoghurt-724875/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192639/cf_259/kebab_pa_kycklingfars_med_pitabrod_och_paprikayoghurt.jpg",
@@ -48223,87 +50725,6 @@
       }
     },
     {
-      "name": "Fläskytterfilé med svampsås",
-      "url": "https://www.ica.se/recept/flaskytterfile-med-svampsas-728358/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_233177/cf_259/flaskytterfilé_med_svampsas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 5,
-      "match_percentage": 38.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färska champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fläskytterfilé",
-          "deal_name": "Fläskytterfilé",
-          "deal_price": null,
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "115:00",
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "babyplommontomater",
-          "deal_name": "Babyplommontomater i ask",
-          "deal_price": "25:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "38:90",
-          "jfr_pris": "50:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "majsstärkelse",
-        "mjölk",
-        "tomatpuré",
-        "japansk soja",
-        "dijonsenap"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 13,
-      "nutrition": {
-        "calories": "683 calories",
-        "protein": "42 g",
-        "fat": "36 g",
-        "carbs": "43 g"
-      }
-    },
-    {
       "name": "Stekt lax och nudelsallad med groddar",
       "url": "https://www.ica.se/recept/stekt-lax-och-nudelsallad-med-groddar-727776/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_228164/cf_259/stekt_lax_och_nudelsallad_med_groddar.jpg",
@@ -48315,7 +50736,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -48396,7 +50817,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -48497,11 +50918,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -48740,11 +51161,11 @@
         {
           "ingredient": "ricottaost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -48841,11 +51262,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -48892,7 +51313,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -48949,87 +51370,6 @@
         "protein": "",
         "fat": "",
         "carbs": ""
-      }
-    },
-    {
-      "name": "Krämig pasta med kycklinglårfilé och basilika",
-      "url": "https://www.ica.se/recept/kramig-pasta-med-kycklinglarfile-och-basilika-724491/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_188185/cf_259/kramig_pasta_med_kycklinglarfilé_och_basilika.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 5,
-      "match_percentage": 38.5,
-      "matched_ingredients": [
-        {
-          "ingredient": "tagliatelle",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kycklinglårfilé",
-          "deal_name": "Kycklinglårfilé",
-          "deal_price": "79.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,97",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "strimlade soltorkade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "vitlöksklyfta",
-        "mjölk",
-        "majsstärkelse",
-        "kruka basilika",
-        "tomatmix"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 23,
-      "nutrition": {
-        "calories": "784 calories",
-        "protein": "43 g",
-        "fat": "38 g",
-        "carbs": "63 g"
       }
     },
     {
@@ -49195,6 +51535,87 @@
       }
     },
     {
+      "name": "Grillad kyckling med gremolata",
+      "url": "https://www.ica.se/recept/grillad-kyckling-med-gremolata-537329/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_15981/cf_259/grillad_kyckling_med_gremolata.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 5,
+      "match_percentage": 38.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "grillad kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "portioner valfri pasta",
+          "deal_name": "EKOLOGISK PASTA",
+          "deal_price": "30:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "broccolistånd",
+          "deal_name": "Broccoli",
+          "deal_price": "15:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "28:90",
+          "jfr_pris": "30:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "soltorkade tomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "kvistar bladpersilja",
+          "deal_name": "BLADPERSILJA 250G",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "79,60",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "svartpeppar",
+        "svarta oliver t ex kalamata",
+        "citron",
+        "-  2 vitlöksklyftor",
+        "olivolja",
+        "salt",
+        "peppar"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.8,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "707 calories",
+        "protein": "",
+        "fat": "37.6 g",
+        "carbs": ""
+      }
+    },
+    {
       "name": "Laxbowl med svart ris",
       "url": "https://www.ica.se/recept/laxbowl-med-svart-ris-726742/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_214211/cf_259/laxbowl_med_svart_ris.jpg",
@@ -49297,7 +51718,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -49354,6 +51775,87 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Kokosmjölksramen med kyckling och majs",
+      "url": "https://www.ica.se/recept/kokosmjolksramen-med-kyckling-och-majs-725880/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_207189/cf_259/kokosmjolksramen_med_kyckling_och_majs.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 5,
+      "match_percentage": 38.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "kycklinglårfilé",
+          "deal_name": "Kycklinglårfilé",
+          "deal_price": "79.90:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,97",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "kokosmjölk",
+          "deal_name": "LAKTOSFRI MJÖLK",
+          "deal_price": "42:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "kycklingbuljongtärningar",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "minimajs",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ramennudlar",
+          "deal_name": "NUDLAR",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "213,98",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "vitlöksklyftor",
+        "vatten",
+        "pak choi",
+        "lime",
+        "sesamfrö"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 39,
+      "nutrition": {
+        "calories": "627 calories",
+        "protein": "33 g",
+        "fat": "34 g",
+        "carbs": "45 g"
       }
     },
     {
@@ -49435,6 +51937,87 @@
         "protein": "27 g",
         "fat": "33 g",
         "carbs": "60 g"
+      }
+    },
+    {
+      "name": "Tomatsoppa med currystekt kyckling och paneer",
+      "url": "https://www.ica.se/recept/tomatsoppa-med-currystekt-kyckling-och-paneer-725813/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203285/cf_259/tomatsoppa_med_currystekt_kyckling_och_paneer.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 13,
+      "matched_count": 5,
+      "match_percentage": 38.5,
+      "matched_ingredients": [
+        {
+          "ingredient": "kokosmjölk",
+          "deal_name": "LAKTOSFRI MJÖLK",
+          "deal_price": "42:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "kycklingbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "ca 400 g currykryddade strimlor av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majsolja",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "paneer ost",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "färsk riven ingefära",
+        "vitlöksklyfta",
+        "tomatsoppa",
+        "vatten",
+        "salt",
+        "svartpeppar",
+        "lime",
+        "kruka gräslök"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 17,
+      "nutrition": {
+        "calories": "548 calories",
+        "protein": "27 g",
+        "fat": "42 g",
+        "carbs": "16 g"
       }
     },
     {
@@ -49631,13 +52214,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "färskpressad citronjuice",
@@ -49652,7 +52235,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -49979,12 +52562,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -50042,7 +52625,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -50061,12 +52644,12 @@
         },
         {
           "ingredient": "rostade pinjenötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -50226,11 +52809,11 @@
         {
           "ingredient": "getost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -50254,88 +52837,6 @@
         "protein": "26 g",
         "fat": "31 g",
         "carbs": "63 g"
-      }
-    },
-    {
-      "name": "Pastasallad med kyckling",
-      "url": "https://www.ica.se/recept/pastasallad-med-kyckling-729700/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248534/cf_259/pastasallad_med_kyckling.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 5,
-      "match_percentage": 35.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "lagrad ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gul eller röd paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "hel grillad kyckling",
-        "rädisor",
-        "kalamataoliver",
-        "basilikapesto",
-        "rödvinsvinäger",
-        "olivolja",
-        "salt",
-        "svartpeppar",
-        "rucola"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 40,
-      "nutrition": {
-        "calories": "949 calories",
-        "protein": "57 g",
-        "fat": "55 g",
-        "carbs": "54 g"
       }
     },
     {
@@ -50389,13 +52890,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -50471,13 +52972,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -50582,88 +53083,6 @@
         "protein": "34 g",
         "fat": "18 g",
         "carbs": "28 g"
-      }
-    },
-    {
-      "name": "Minutfilé med rostad potatis och morotssallad",
-      "url": "https://www.ica.se/recept/minutfile-med-rostad-potatis-och-morotssallad-725590/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_198188/cf_259/minutfilé_med_rostad_potatis_och_morotssallad.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 5,
-      "match_percentage": 35.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "morötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kyld sås",
-          "deal_name": "KYLD SÅS, DRESSING",
-          "deal_price": "35:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "persilja",
-          "deal_name": "BLADPERSILJA 250G",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "79,60",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ca 2 msk olivolja",
-        "salt",
-        "vitpeppar",
-        "- ca 1 msk olivolja",
-        "vinäger",
-        "skalet av 1 citron",
-        "minutfilé av kyckling",
-        "svartpeppar",
-        "olja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 14,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -50881,12 +53300,12 @@
         },
         {
           "ingredient": "rostade, saltade jordnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -50910,88 +53329,6 @@
         "protein": "14 g",
         "fat": "25 g",
         "carbs": "36 g"
-      }
-    },
-    {
-      "name": "Kyckling chili",
-      "url": "https://www.ica.se/recept/kyckling-chili-721063/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_164399/cf_259/kyckling_chili.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 5,
-      "match_percentage": 35.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "pulled chicken",
-          "deal_name": "PULLED PORK",
-          "deal_price": "39.90:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "72,55",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "krossade tomater",
-          "deal_name": "Krossade tomater",
-          "deal_price": "30:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "37,50",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "mild chunky salsa",
-          "deal_name": "Mild kvarg/Grekisk Yoghurt",
-          "deal_price": "35:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "48:95-52:00",
-          "jfr_pris": "35:00",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "riven ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gräddfil",
-          "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "vitlöksklyfta",
-        "av bbq-sås",
-        "oregano",
-        "chiliflakes",
-        "vatten",
-        "bönmix",
-        "majskorn",
-        "salt",
-        "nachochips"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -51036,7 +53373,7 @@
         {
           "ingredient": "baguette",
           "deal_name": "Baguette",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -51046,11 +53383,11 @@
         {
           "ingredient": "riven  ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         }
       ],
@@ -51129,11 +53466,11 @@
         {
           "ingredient": "ca 400 g halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -51161,89 +53498,6 @@
       }
     },
     {
-      "name": "Krispig kyckling-schnitzel med kapriskräm",
-      "url": "https://www.ica.se/recept/krispig-kyckling-schnitzel-med-kapriskram-721467/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_153248/cf_259/krispig_kycklingschnitzel_med_kapriskram.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 5,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ägg",
-          "deal_name": "ÄGG, FRIGÅENDE",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "dijonsenap",
-        "ca 600 g minutfilé av kyckling",
-        "olja",
-        "kapris",
-        "citron",
-        "mâchesallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 35,
-      "nutrition": {
-        "calories": "767 calories",
-        "protein": "45.3 g",
-        "fat": "32.1 g",
-        "carbs": "69.8 g"
-      }
-    },
-    {
       "name": "Pasta med svampsås och päronsallad",
       "url": "https://www.ica.se/recept/pasta-med-svampsas-och-paronsallad-729153/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241380/cf_259/pasta_med_svampsas_och_paronsallad.jpg",
@@ -51264,12 +53518,12 @@
         },
         {
           "ingredient": "kyld ostsås för pasta",
-          "deal_name": "Riven ost",
+          "deal_name": "EKOLOGISK PASTA",
           "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "30",
           "match_score": 0.9
         },
         {
@@ -51294,12 +53548,12 @@
         },
         {
           "ingredient": "rostade pumpakärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -51368,7 +53622,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -51378,7 +53632,7 @@
         {
           "ingredient": "ca 400 g varmrökt lax",
           "deal_name": "VARMRÖKT REGNBÅGSLAX",
-          "deal_price": "Medlemspris",
+          "deal_price": "119:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -51451,7 +53705,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -51461,7 +53715,7 @@
         {
           "ingredient": "ca 400 g varmrökt lax",
           "deal_name": "VARMRÖKT REGNBÅGSLAX",
-          "deal_price": "Medlemspris",
+          "deal_price": "119:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -51699,13 +53953,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "hyvlad parmesan",
@@ -51856,11 +54110,11 @@
         {
           "ingredient": "riven prästost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -52107,11 +54361,11 @@
         {
           "ingredient": "getost av chèvretyp",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -52244,90 +54498,6 @@
       }
     },
     {
-      "name": "Fläskytterfilé med gräddsås och pressgurka",
-      "url": "https://www.ica.se/recept/flaskytterfile-med-graddsas-och-pressgurka-728474/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234608/cf_259/flaskytterfilé_med_graddsas_och_pressgurka.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 16,
-      "matched_count": 5,
-      "match_percentage": 31.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "färsk persilja",
-          "deal_name": "BLADPERSILJA 250G",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "79,60",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fläskytterfilé",
-          "deal_name": "Fläskytterfilé",
-          "deal_price": null,
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "115:00",
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "köttbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölig potatis",
-        "mjölk",
-        "salt",
-        "peppar",
-        "ättiksprit",
-        "strösocker",
-        "salt",
-        "vatten",
-        "olja",
-        "mjölk",
-        "majsstärkelse"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 16,
-      "nutrition": {
-        "calories": "603 calories",
-        "protein": "44 g",
-        "fat": "23 g",
-        "carbs": "54 g"
-      }
-    },
-    {
       "name": "Pasta på kålrot med kantareller och surkål",
       "url": "https://www.ica.se/recept/pasta-pa-kalrot-med-kantareller-och-surkal-728381/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_231534/cf_259/pasta_pa_kalrot_med_kantareller_och_surkal.jpg",
@@ -52412,90 +54582,6 @@
       }
     },
     {
-      "name": "Rödbetor med rostade vindruvor och minutbiff",
-      "url": "https://www.ica.se/recept/rodbetor-med-rostade-vindruvor-och-minutbiff-727192/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218620/cf_259/rodbetor_med_rostade_vindruvor_och_minutbiff.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 16,
-      "matched_count": 5,
-      "match_percentage": 31.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödbetor",
-          "deal_name": "Rödbetor",
-          "deal_price": "12:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "12",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "valnötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "röda kärnfria vindruvor",
-          "deal_name": "Röda kärnfria druvor i ask",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse sallad",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "olivolja",
-        "salt",
-        "olivolja",
-        "äppelcidervinäger",
-        "dijonsenap",
-        "salt",
-        "svartpeppar",
-        "ca 600 g minutbiff",
-        "salt",
-        "svartpeppar",
-        "ca 200 g chèvre"
-      ],
-      "time": "PT90M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 12,
-      "nutrition": {
-        "calories": "712 calories",
-        "protein": "47 g",
-        "fat": "44 g",
-        "carbs": "28 g"
-      }
-    },
-    {
       "name": "Svampbuljong med kyckling och jordärtskocka",
       "url": "https://www.ica.se/recept/svampbuljong-med-kyckling-och-jordartskocka-727189/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218258/cf_259/svampbuljong_med_kyckling_och_jordartskocka.jpg",
@@ -52580,90 +54666,6 @@
       }
     },
     {
-      "name": "Rödbetor med rostade vindruvor och minutbiff",
-      "url": "https://www.ica.se/recept/rodbetor-med-rostade-vindruvor-och-minutbiff-727192/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218620/cf_259/rodbetor_med_rostade_vindruvor_och_minutbiff.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 16,
-      "matched_count": 5,
-      "match_percentage": 31.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "rödbetor",
-          "deal_name": "Rödbetor",
-          "deal_price": "12:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "12",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "valnötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "röda kärnfria vindruvor",
-          "deal_name": "Röda kärnfria druvor i ask",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse sallad",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "olivolja",
-        "salt",
-        "olivolja",
-        "äppelcidervinäger",
-        "dijonsenap",
-        "salt",
-        "svartpeppar",
-        "ca 600 g minutbiff",
-        "salt",
-        "svartpeppar",
-        "ca 200 g chèvre"
-      ],
-      "time": "PT90M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 12,
-      "nutrition": {
-        "calories": "712 calories",
-        "protein": "47 g",
-        "fat": "44 g",
-        "carbs": "28 g"
-      }
-    },
-    {
       "name": "Svampbuljong med kyckling och jordärtskocka",
       "url": "https://www.ica.se/recept/svampbuljong-med-kyckling-och-jordartskocka-727189/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_218258/cf_259/svampbuljong_med_kyckling_och_jordartskocka.jpg",
@@ -52745,90 +54747,6 @@
         "protein": "22 g",
         "fat": "13 g",
         "carbs": "12 g"
-      }
-    },
-    {
-      "name": "Krämig kycklinggryta med fänkål och timjan",
-      "url": "https://www.ica.se/recept/kramig-kycklinggryta-med-fankal-och-timjan-724546/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_192253/cf_259/kramig_kycklinggryta_med_fankal_och_timjan.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 16,
-      "matched_count": 5,
-      "match_percentage": 31.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kycklinglårfilé",
-          "deal_name": "Kycklinglårfilé",
-          "deal_price": "79.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,97",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "kycklingbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "fänkål",
-        "olivolja",
-        "kruka timjan",
-        "salt",
-        "peppar",
-        "majsstärkelse",
-        "mjölk",
-        "citron",
-        "tomatmix",
-        "rödvinsvinäger",
-        "olivolja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 13,
-      "nutrition": {
-        "calories": "684 calories",
-        "protein": "40 g",
-        "fat": "33 g",
-        "carbs": "53 g"
       }
     },
     {
@@ -52997,91 +54915,6 @@
         "protein": "23 g",
         "fat": "37 g",
         "carbs": "82 g"
-      }
-    },
-    {
-      "name": "Tofu med broccoli i sötsur ingefärssås",
-      "url": "https://www.ica.se/recept/tofu-med-broccoli-i-sotsur-ingefarssas-750497/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/vdoy7jk6yvsieogj1sv4.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 17,
-      "matched_count": 5,
-      "match_percentage": 29.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "majsstärkelse eller potatismjöl",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "broccoli",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rapsolja",
-          "deal_name": "Rapsolja",
-          "deal_price": "49:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "strimlad salladslök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "fast tofu",
-        "salt",
-        "riven färsk ingefära",
-        "vitlöksklyftor",
-        "japansk soja",
-        "strösocker",
-        "risvinäger",
-        "sesamolja",
-        "majsstärkelse",
-        "vatten",
-        "jasminris",
-        "sesamfrön"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 32,
-      "nutrition": {
-        "calories": "573 calories",
-        "protein": "19 g",
-        "fat": "21 g",
-        "carbs": "73 g"
       }
     },
     {
@@ -53380,12 +55213,12 @@
         },
         {
           "ingredient": "hackade, rostade sötmandlar",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -53422,6 +55255,178 @@
         "protein": "",
         "fat": "",
         "carbs": ""
+      }
+    },
+    {
+      "name": "Ugnsbakad spätta med dill- och caviarsås",
+      "url": "https://www.ica.se/recept/ugnsbakad-spatta-med-dill-och-caviarsas-729550/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247911/cf_259/ugnsbakad_spatta_med_dill-_och_caviarsas .jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 5,
+      "match_percentage": 27.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spättafilé eller alaska pollock",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fiskbuljong",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölig potatis",
+        "mjölk",
+        "salt",
+        "peppar",
+        "ättiksprit",
+        "strösocker",
+        "vatten",
+        "salt",
+        "vitpeppar",
+        "ca 2 dillvippor",
+        "färsk dill",
+        "röd caviar",
+        "spröd salladsmix"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "487 calories",
+        "protein": "43 g",
+        "fat": "12 g",
+        "carbs": "47 g"
+      }
+    },
+    {
+      "name": "Ugnsbakad spätta med dill- och caviarsås",
+      "url": "https://www.ica.se/recept/ugnsbakad-spatta-med-dill-och-caviarsas-729550/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247911/cf_259/ugnsbakad_spatta_med_dill-_och_caviarsas .jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 18,
+      "matched_count": 5,
+      "match_percentage": 27.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "spättafilé eller alaska pollock",
+          "deal_name": "Läsk",
+          "deal_price": "30:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "24:90",
+          "jfr_pris": "10:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fiskbuljong",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "matlagningsgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölig potatis",
+        "mjölk",
+        "salt",
+        "peppar",
+        "ättiksprit",
+        "strösocker",
+        "vatten",
+        "salt",
+        "vitpeppar",
+        "ca 2 dillvippor",
+        "färsk dill",
+        "röd caviar",
+        "spröd salladsmix"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "487 calories",
+        "protein": "43 g",
+        "fat": "12 g",
+        "carbs": "47 g"
       }
     },
     {
@@ -53522,11 +55527,11 @@
         {
           "ingredient": "kycklingbröstfiléer",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -53552,7 +55557,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -53598,6 +55603,93 @@
       }
     },
     {
+      "name": "Ärtig falafel med snabbsyrad rödlök",
+      "url": "https://www.ica.se/recept/artig-falafel-med-snabbsyrad-rodlok-721123/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_145939/cf_259/artig_falafel_med_snabbsyrad_rodlok.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 19,
+      "matched_count": 5,
+      "match_percentage": 26.3,
+      "matched_ingredients": [
+        {
+          "ingredient": "gul lök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "-  1 dl majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "små tortillabröd",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "avokado",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "vitlöksklyfta",
+        "groddade gula ärtor",
+        "finhackad persilja",
+        "malen spiskummin",
+        "torkad koriander",
+        "bakpulver",
+        "sambal oelek",
+        "salt",
+        "olivolja",
+        "vit- eller rödvinsvinäger",
+        "salt",
+        "solrosskott",
+        "hummus",
+        "lime"
+      ],
+      "time": "PT90M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 18,
+      "nutrition": {
+        "calories": "540 calories",
+        "protein": "11 g",
+        "fat": "27 g",
+        "carbs": "59 g"
+      }
+    },
+    {
       "name": "Croque monsieur",
       "url": "https://www.ica.se/recept/croque-monsieur-729938/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/swk4ktmrskvnp4hvm5aa.jpg",
@@ -53629,11 +55721,11 @@
         {
           "ingredient": "skivor lagrad ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -53682,18 +55774,18 @@
         },
         {
           "ingredient": "smulad fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "riven mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -53986,71 +56078,6 @@
       }
     },
     {
-      "name": "Paprikagratinerad kassler med tomat",
-      "url": "https://www.ica.se/recept/paprikagratinerad-kassler-med-tomat-725044/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_195910/cf_259/paprikagratinerad_kassler_med_tomat.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 6,
-      "matched_count": 4,
-      "match_percentage": 66.7,
-      "matched_ingredients": [
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "pestopaprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "påse riven  ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "körsbärstomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ca 600 g kassler",
-        "ris eller annat gryn"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 17,
-      "nutrition": {
-        "calories": "750 calories",
-        "protein": "43 g",
-        "fat": "40 g",
-        "carbs": "52 g"
-      }
-    },
-    {
       "name": "Krämig kycklingpasta med vitt vin och tomat",
       "url": "https://www.ica.se/recept/kramig-kycklingpasta-med-vitt-vin-och-tomat-722481/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_165129/cf_259/kramig_kycklingpasta_med_vitt_vin_och_tomat.jpg",
@@ -54116,6 +56143,72 @@
       }
     },
     {
+      "name": "Quesadilla med skinka och mjukost med jalapeño",
+      "url": "https://www.ica.se/recept/quesadilla-med-skinka-och-mjukost-med-jalapeno-750030/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/przeb3qz6cr6glgssyvk.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 7,
+      "matched_count": 4,
+      "match_percentage": 57.1,
+      "matched_ingredients": [
+        {
+          "ingredient": "pressad skinka",
+          "deal_name": "STRIMLAD RÖKT SKINKA",
+          "deal_price": "19.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "110,56",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "mjukost hot jalapeño",
+          "deal_name": "Riven ost",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tortillabröd medium",
+          "deal_name": "Bröd",
+          "deal_price": "25:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "59,52",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "salt",
+        "svartpeppar",
+        "matolja"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 5,
+      "nutrition": {
+        "calories": "931 calories",
+        "protein": "40 g",
+        "fat": "40 g",
+        "carbs": "99 g"
+      }
+    },
+    {
       "name": "Krämig pasta med bresaola",
       "url": "https://www.ica.se/recept/kramig-pasta-med-bresaola-725167/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_197316/cf_259/kramig_pasta_med_bresaola.jpg",
@@ -54136,13 +56229,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "tomater",
@@ -54259,12 +56352,12 @@
       "matched_ingredients": [
         {
           "ingredient": "skivat bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
+          "deal_name": "SKIVAT BACON 5-PACK",
+          "deal_price": "58.90:-",
+          "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": null,
+          "jfr_pris": "117,80",
           "match_score": 0.9
         },
         {
@@ -54393,12 +56486,12 @@
       "matched_ingredients": [
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -54480,13 +56573,13 @@
         },
         {
           "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.9
         },
         {
           "ingredient": "smör",
@@ -54561,7 +56654,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -54625,7 +56718,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -54691,13 +56784,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
@@ -54805,12 +56898,12 @@
         },
         {
           "ingredient": "skivor cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -54989,6 +57082,142 @@
       }
     },
     {
+      "name": "Stekt kyckling med dipp på fetaost",
+      "url": "https://www.ica.se/recept/stekt-kyckling-med-dipp-pa-fetaost-726867/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_217878/cf_259/stekt_kyckling_med_dipp_pa_fetaost.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 9,
+      "matched_count": 4,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "snackpaprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "påse röd mangold",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris eller annat gryn",
+        "smetana",
+        "peppar",
+        "olja",
+        "salt"
+      ],
+      "time": "PT30M",
+      "servings": "2",
+      "rating": 4.6,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "695 calories",
+        "protein": "42 g",
+        "fat": "36 g",
+        "carbs": "51 g"
+      }
+    },
+    {
+      "name": "Gratinerad kyckling med grillad paprika",
+      "url": "https://www.ica.se/recept/gratinerad-kyckling-med-grillad-paprika-724360/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_186059/cf_259/gratinerad_kyckling_med_grillad_paprika.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 9,
+      "matched_count": 4,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "grillad paprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "crème fraiche fetaost & soltorkade tomater",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "påse mangold",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris",
+        "olja",
+        "salt",
+        "peppar",
+        "ask färsk persilja"
+      ],
+      "time": "PT30M",
+      "servings": "2",
+      "rating": 4.5,
+      "reviews": 28,
+      "nutrition": {
+        "calories": "684 calories",
+        "protein": "37 g",
+        "fat": "33 g",
+        "carbs": "60 g"
+      }
+    },
+    {
       "name": "Torsk med romsås",
       "url": "https://www.ica.se/recept/torsk-med-romsas-723439/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_176471/cf_259/torsk_med_romsas.jpg",
@@ -55125,6 +57354,142 @@
       }
     },
     {
+      "name": "Stekt kyckling med dipp på fetaost",
+      "url": "https://www.ica.se/recept/stekt-kyckling-med-dipp-pa-fetaost-726867/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_217878/cf_259/stekt_kyckling_med_dipp_pa_fetaost.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 9,
+      "matched_count": 4,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "fetaost",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "snackpaprika",
+          "deal_name": "Röd spetspaprika i påse",
+          "deal_price": "18:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "26:95",
+          "jfr_pris": "90:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "påse röd mangold",
+          "deal_name": "Mango",
+          "deal_price": "30:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "45,45",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "ris eller annat gryn",
+        "smetana",
+        "peppar",
+        "olja",
+        "salt"
+      ],
+      "time": "PT30M",
+      "servings": "2",
+      "rating": 4.6,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "695 calories",
+        "protein": "42 g",
+        "fat": "36 g",
+        "carbs": "51 g"
+      }
+    },
+    {
+      "name": "Biff med rostad potatis och vitlökskräm",
+      "url": "https://www.ica.se/recept/biff-med-rostad-potatis-och-vitlokskram-726130/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_212506/cf_259/biff_med_rostad_potatis_och_vitlokskram.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 9,
+      "matched_count": 4,
+      "match_percentage": 44.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "delikatesspotatis",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "skivor ryggbiff",
+          "deal_name": "Färsk biff",
+          "deal_price": "59.90:-",
+          "deal_store": "Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "332,78",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "pärltomater",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "vitlöksklyfta",
+        "krispsallad"
+      ],
+      "time": "PT45M",
+      "servings": "2",
+      "rating": 4.5,
+      "reviews": 17,
+      "nutrition": {
+        "calories": "599 calories",
+        "protein": "35 g",
+        "fat": "29 g",
+        "carbs": "46 g"
+      }
+    },
+    {
       "name": "Kycklingben med currysås",
       "url": "https://www.ica.se/recept/kycklingben-med-currysas-717373/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_90719/cf_259/kycklingben_med_currysas.jpg",
@@ -55136,7 +57501,7 @@
         {
           "ingredient": "kycklingben",
           "deal_name": "KYCKLINGBEN",
-          "deal_price": "Medlemspris",
+          "deal_price": "59.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -55400,75 +57765,6 @@
       }
     },
     {
-      "name": "Krispiga smashed potatoes",
-      "url": "https://www.ica.se/recept/krispiga-smashed-potatoes-722468/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_168736/cf_259/smashed_potatoes_med_ortsmor_.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 10,
-      "matched_count": 4,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "amadine potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "panko eller vanligt ströbröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "röd mangold",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "45,45",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olivolja",
-        "rosmarin",
-        "timjan",
-        "flingsalt",
-        "nymald svartpeppar",
-        "grillad kyckling"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 141,
-      "nutrition": {
-        "calories": "527 calories",
-        "protein": "34 g",
-        "fat": "24 g",
-        "carbs": "41 g"
-      }
-    },
-    {
       "name": "Spaghetti alla puttanesca",
       "url": "https://www.ica.se/recept/spaghetti-alla-puttanesca-714031/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_249643/cf_259/spaghetti_alla_puttanesca.jpg",
@@ -55558,13 +57854,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "körsbärstomater",
@@ -55604,6 +57900,75 @@
         "protein": "34 g",
         "fat": "44 g",
         "carbs": "58 g"
+      }
+    },
+    {
+      "name": "Kycklingfilé med vitlökssås och klyftpotatis",
+      "url": "https://www.ica.se/recept/kycklingfile-med-vitlokssas-och-klyftpotatis-725259/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_198707/cf_259/kycklingfilé_med_vitlokssas_och_klyftpotatis.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 10,
+      "matched_count": 4,
+      "match_percentage": 40.0,
+      "matched_ingredients": [
+        {
+          "ingredient": "ca 600 g minutfilé av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "crème fraiche",
+          "deal_name": "Crème Fraiche",
+          "deal_price": "24:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "15:90-22:90",
+          "jfr_pris": "60:00",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "marinad",
+        "olja",
+        "salt",
+        "peppar",
+        "vitlöksklyfta",
+        "isbergssallad"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 21,
+      "nutrition": {
+        "calories": "561 calories",
+        "protein": "30 g",
+        "fat": "23 g",
+        "carbs": "55 g"
       }
     },
     {
@@ -55697,11 +58062,11 @@
         {
           "ingredient": "sats rostbiff",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -55717,11 +58082,11 @@
         {
           "ingredient": "sats råkostsallad",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -55742,75 +58107,6 @@
         "protein": "",
         "fat": "",
         "carbs": ""
-      }
-    },
-    {
-      "name": "Krämig pasta med pesto och bacon",
-      "url": "https://www.ica.se/recept/kramig-pasta-med-pesto-och-bacon-724880/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_190999/cf_259/kramig_pasta_med_pesto_och_bacon.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 10,
-      "matched_count": 4,
-      "match_percentage": 40.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "bacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "champinjoner",
-          "deal_name": "Champinjoner",
-          "deal_price": "30:-",
-          "deal_store": "Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "60",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "majsstärkelse",
-        "mjölk",
-        "basilika pesto",
-        "svartpeppar",
-        "ev salt"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 25,
-      "nutrition": {
-        "calories": "684 calories",
-        "protein": "26 g",
-        "fat": "38 g",
-        "carbs": "58 g"
       }
     },
     {
@@ -55854,12 +58150,12 @@
         },
         {
           "ingredient": "rostat bröd",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -55914,11 +58210,11 @@
         {
           "ingredient": "riven ost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 1.0
         },
         {
@@ -55992,12 +58288,12 @@
         },
         {
           "ingredient": "grovhackade, torrostade  jordnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -56091,76 +58387,6 @@
       }
     },
     {
-      "name": "Kycklingfilé med klyftpotatis och fänkålssallad",
-      "url": "https://www.ica.se/recept/kycklingfile-med-klyftpotatis-och-fankalssallad-727559/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_226001/cf_259/kycklingfilé_med_klyftpotatis_och_fankalssallad.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 4,
-      "match_percentage": 36.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "smör eller olja",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "äpple- och currysås",
-          "deal_name": "Svenska äpplen",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "31:90-36:90",
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "fänkål",
-        "citron",
-        "olivolja",
-        "snabbfiléer av kyckling"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "768 calories",
-        "protein": "40 g",
-        "fat": "52 g",
-        "carbs": "33 g"
-      }
-    },
-    {
       "name": "Pasta med kryddkorvsröra och oliver",
       "url": "https://www.ica.se/recept/pasta-med-kryddkorvsrora-och-oliver-727547/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_224484/cf_259/pasta_med_kryddkorvsrora_och_oliver_.jpg",
@@ -56201,12 +58427,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -56301,16 +58527,46 @@
       }
     },
     {
-      "name": "Krämig pancettapasta",
-      "url": "https://www.ica.se/recept/kramig-pancettapasta-717575/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_93277/cf_259/kramig_pancettapasta.jpg",
+      "name": "Tonfiskröra med curry och bakade potatisar",
+      "url": "https://www.ica.se/recept/tonfiskrora-med-curry-och-bakade-potatisar-726033/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210659/cf_259/tonfiskrora_med_curry_och_bakade_potatisar.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 11,
       "matched_count": 4,
       "match_percentage": 36.4,
       "matched_ingredients": [
         {
-          "ingredient": "purjolök",
+          "ingredient": "delikatesspotatis",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tonfisk i vatten",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "rödlök",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -56318,196 +58574,26 @@
           "ord_pris": null,
           "jfr_pris": "99:00",
           "match_score": 0.85
-        },
-        {
-          "ingredient": "spaghetti",
-          "deal_name": "SPAGHETTI",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "19,90",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rostade solroskärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "bellaverde",
-        "pancetta",
-        "mjölk",
-        "majsstärkelse",
+        "olja",
         "salt",
         "peppar",
-        "salladsmix"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "599 calories",
-        "protein": "30.6 g",
-        "fat": "26.2 g",
-        "carbs": "56.5 g"
-      }
-    },
-    {
-      "name": "Kycklingpasta med ärtpesto och grillad paprika",
-      "url": "https://www.ica.se/recept/kycklingpasta-med-artpesto-och-grillad-paprika-725909/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_204692/cf_259/kycklingpasta_med_artpesto_och_grillad_paprika.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 4,
-      "match_percentage": 36.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "gröna ärtor",
-          "deal_name": "GRÖNA KÄRNFRIA DRUVOR I ASK",
-          "deal_price": "25:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "50",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "ca 500 g kycklingfilé",
-          "deal_name": "Färsk kycklingfilé",
-          "deal_price": "119:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/kg",
-          "ord_pris": "179:00",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "grönsaksbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 1.0
-        }
-      ],
-      "unmatched_ingredients": [
-        "basilika pesto",
-        "salt",
-        "peppar",
-        "grillade paprikor",
-        "majsolja",
-        "vatten",
-        "babyspenat"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 7,
-      "nutrition": {
-        "calories": "623 calories",
-        "protein": "44 g",
-        "fat": "23 g",
-        "carbs": "58 g"
-      }
-    },
-    {
-      "name": "Rotmos med asiatiska smaker",
-      "url": "https://www.ica.se/recept/rotmos-med-asiatiska-smaker-722222/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_165095/cf_259/rotmos_med_asiatiska_smaker.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 4,
-      "match_percentage": 36.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "kålrot",
-          "deal_name": "Rotselleri, Kålrot",
-          "deal_price": "15:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "15",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "medelstora potatisar",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "brynt smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "morot",
-        "riven, färsk ingefära",
-        "röd chili",
-        "japansk soja",
-        "sesamolja",
-        "salt",
-        "lax eller kyckling"
+        "curry",
+        "smetana",
+        "chilisås",
+        "kruksallad"
       ],
       "time": "PT45M",
       "servings": "4",
       "rating": 4.6,
-      "reviews": 5,
+      "reviews": 19,
       "nutrition": {
-        "calories": "445 calories",
-        "protein": "33 g",
-        "fat": "20 g",
-        "carbs": "27 g"
+        "calories": "583 calories",
+        "protein": "28 g",
+        "fat": "29 g",
+        "carbs": "49 g"
       }
     },
     {
@@ -56535,7 +58621,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         },
@@ -56651,76 +58737,6 @@
       }
     },
     {
-      "name": "Krämig pancettapasta",
-      "url": "https://www.ica.se/recept/kramig-pancettapasta-717575/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_93277/cf_259/kramig_pancettapasta.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 4,
-      "match_percentage": 36.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "purjolök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "spaghetti",
-          "deal_name": "SPAGHETTI",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "19,90",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "rostade solroskärnor",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "bellaverde",
-        "pancetta",
-        "mjölk",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "salladsmix"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 6,
-      "nutrition": {
-        "calories": "599 calories",
-        "protein": "30.6 g",
-        "fat": "26.2 g",
-        "carbs": "56.5 g"
-      }
-    },
-    {
       "name": "Vodkapasta",
       "url": "https://www.ica.se/recept/vodkapasta-729011/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_238327/cf_259/vodkapasta.jpg",
@@ -56765,7 +58781,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -56802,22 +58818,22 @@
       "matched_ingredients": [
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -56873,22 +58889,22 @@
       "matched_ingredients": [
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -57289,77 +59305,6 @@
       }
     },
     {
-      "name": "Stekt lax med krämig salladskål",
-      "url": "https://www.ica.se/recept/stekt-lax-med-kramig-salladskal-725552/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_202888/cf_259/stekt_lax_med_kramig_salladskal.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 12,
-      "matched_count": 4,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "delikatesspotatis",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "laxfilé",
-          "deal_name": "Färsk laxfilé",
-          "deal_price": "149:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "149",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "påse fish taco kryddmix",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "majskorn",
-        "salladskål eller sommarkål",
-        "ask persilja",
-        "dijonsenap",
-        "olja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 7,
-      "nutrition": {
-        "calories": "720 calories",
-        "protein": "35 g",
-        "fat": "41 g",
-        "carbs": "48 g"
-      }
-    },
-    {
       "name": "Krämig kalkongryta med mango chutney",
       "url": "https://www.ica.se/recept/kramig-kalkongryta-med-mango-chutney-725823/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_208374/cf_259/kramig_kalkongryta_med_mango_chutney.jpg",
@@ -57471,12 +59416,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -57500,78 +59445,6 @@
         "protein": "25 g",
         "fat": "27 g",
         "carbs": "75 g"
-      }
-    },
-    {
-      "name": "Citronbakad lax med dillsås och hjärtsallad",
-      "url": "https://www.ica.se/recept/citronbakad-lax-med-dillsas-och-hjartsallad-729647/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248779/cf_259/citronbakad_lax_med_dillsas_och_stekt_hjartsallad .jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 4,
-      "match_percentage": 30.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "laxfilé",
-          "deal_name": "Färsk laxfilé",
-          "deal_price": "149:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "149",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "skaldjurs- eller fiskbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "citron",
-        "salt",
-        "peppar",
-        "majsstärkelse",
-        "mjölk",
-        "färsk dill",
-        "hjärtsalladshuvuden",
-        "olivolja",
-        "färskpressad citronsaft"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.9,
-      "reviews": 16,
-      "nutrition": {
-        "calories": "",
-        "protein": "",
-        "fat": "",
-        "carbs": ""
       }
     },
     {
@@ -57615,12 +59488,12 @@
         },
         {
           "ingredient": "rostad lök",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -57719,6 +59592,78 @@
       }
     },
     {
+      "name": "Rårakepizza med rökt lax",
+      "url": "https://www.ica.se/recept/rarakepizza-med-rokt-lax-729819/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248780/cf_259/rarakepizza_med_rokt_lax.jpg",
+      "category": "Brunch",
+      "total_ingredients": 13,
+      "matched_count": 4,
+      "match_percentage": 30.8,
+      "matched_ingredients": [
+        {
+          "ingredient": "fast potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tunt skivad rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "smör",
+          "deal_name": "Smör",
+          "deal_price": "55:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "78:00",
+          "jfr_pris": "110:00",
+          "match_score": 1.0
+        }
+      ],
+      "unmatched_ingredients": [
+        "smetana",
+        "finriven pepparrot",
+        "finrivet  citronskal",
+        "salt",
+        "kallrökt lax",
+        "finskuren gräslök",
+        "olja",
+        "svartpeppar",
+        "färsk dill"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 25,
+      "nutrition": {
+        "calories": "322 calories",
+        "protein": "11 g",
+        "fat": "19 g",
+        "carbs": "26 g"
+      }
+    },
+    {
       "name": "Ugnsrostade gulbetor med fetaost och hasselnötter",
       "url": "https://www.ica.se/recept/ugnsrostade-gulbetor-med-fetaost-och-hasselnotter-729040/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241370/cf_259/ugnsrostade_gulbetor_med_fetaost_och_hasselnotter__.jpg",
@@ -57749,22 +59694,22 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
           "ingredient": "rostade hasselnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -57832,11 +59777,11 @@
         {
           "ingredient": "ca 150 g lagrad hårdost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -57883,13 +59828,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "vispgrädde",
@@ -57935,150 +59880,6 @@
       }
     },
     {
-      "name": "Grillad kyckling med gremolata",
-      "url": "https://www.ica.se/recept/grillad-kyckling-med-gremolata-537329/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_15981/cf_259/grillad_kyckling_med_gremolata.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 4,
-      "match_percentage": 30.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "portioner valfri pasta",
-          "deal_name": "EKOLOGISK PASTA",
-          "deal_price": "30:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "30",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "broccolistånd",
-          "deal_name": "Broccoli",
-          "deal_price": "15:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "28:90",
-          "jfr_pris": "30:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "soltorkade tomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "kvistar bladpersilja",
-          "deal_name": "BLADPERSILJA 250G",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "79,60",
-          "match_score": 0.75
-        }
-      ],
-      "unmatched_ingredients": [
-        "grillad kyckling",
-        "salt",
-        "svartpeppar",
-        "svarta oliver t ex kalamata",
-        "citron",
-        "-  2 vitlöksklyftor",
-        "olivolja",
-        "salt",
-        "peppar"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.8,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "707 calories",
-        "protein": "",
-        "fat": "37.6 g",
-        "carbs": ""
-      }
-    },
-    {
-      "name": "Kokosmjölksramen med kyckling och majs",
-      "url": "https://www.ica.se/recept/kokosmjolksramen-med-kyckling-och-majs-725880/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_207189/cf_259/kokosmjolksramen_med_kyckling_och_majs.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 4,
-      "match_percentage": 30.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "kycklinglårfilé",
-          "deal_name": "Kycklinglårfilé",
-          "deal_price": "79.90:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,97",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "kokosmjölk",
-          "deal_name": "LAKTOSFRI MJÖLK",
-          "deal_price": "42:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kycklingbuljongtärningar",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "ramennudlar",
-          "deal_name": "NUDLAR",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "213,98",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "vitlöksklyftor",
-        "vatten",
-        "minimajs",
-        "pak choi",
-        "lime",
-        "sesamfrö"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 39,
-      "nutrition": {
-        "calories": "627 calories",
-        "protein": "33 g",
-        "fat": "34 g",
-        "carbs": "45 g"
-      }
-    },
-    {
       "name": "Pappardelle med kronärtskockssås",
       "url": "https://www.ica.se/recept/pappardelle-med-kronartskockssas-722904/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_169839/cf_259/pappardelle_med_kronartskockssas.jpg",
@@ -58099,13 +59900,13 @@
         },
         {
           "ingredient": "haricots verts",
-          "deal_name": "Sockerärtor/Sugarsnaps/Haricot Verts",
-          "deal_price": "50:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
+          "deal_name": "Sockerärtor/sugarsnaps/haricots verts (Guatemala/Zimbabwe/Kenya)",
+          "deal_price": "2 för 55:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
           "ord_pris": null,
-          "jfr_pris": "166,67",
-          "match_score": 0.75
+          "jfr_pris": "183,33/kg.",
+          "match_score": 0.9
         },
         {
           "ingredient": "vispgrädde",
@@ -58223,6 +60024,79 @@
       }
     },
     {
+      "name": "Torskgratäng med dillsås och pepparrotsgurka",
+      "url": "https://www.ica.se/recept/torskgratang-med-dillsas-och-pepparrotsgurka-729553/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248117/cf_259/fiskgratang_med_dill_och_pepparrotsgurka.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 4,
+      "match_percentage": 28.6,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatisar",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "vispgrädde",
+          "deal_name": "Vispgrädde",
+          "deal_price": "29:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "fiskbuljongtärning",
+          "deal_name": "Buljong",
+          "deal_price": "30:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "2 för",
+          "ord_pris": "22:95",
+          "jfr_pris": "2:50",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "mjölk",
+        "salt",
+        "peppar",
+        "färsk dill",
+        "torskfilé",
+        "snackgurka",
+        "riven pepparrot",
+        "citron",
+        "olivolja",
+        "hackad färsk dill"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 13,
+      "nutrition": {
+        "calories": "587 calories",
+        "protein": "35 g",
+        "fat": "30 g",
+        "carbs": "41 g"
+      }
+    },
+    {
       "name": "Melanzane alla parmigiana",
       "url": "https://www.ica.se/recept/melanzane-alla-parmigiana-729477/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_243747/cf_259/melanzane_alla_parmigiana.jpg",
@@ -58254,7 +60128,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -58515,6 +60389,80 @@
       }
     },
     {
+      "name": "Glacerad kyckling med avokadoröra",
+      "url": "https://www.ica.se/recept/glacerad-kyckling-med-avokadorora-728976/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_240537/cf_259/glacerad_kyckling_med_avokadorora.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 15,
+      "matched_count": 4,
+      "match_percentage": 26.7,
+      "matched_ingredients": [
+        {
+          "ingredient": "potatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "plommontomater",
+          "deal_name": "Plommontomater",
+          "deal_price": "20:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "40",
+          "match_score": 1.0
+        },
+        {
+          "ingredient": "avokador",
+          "deal_name": "Avokado",
+          "deal_price": "20:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "2 för",
+          "ord_pris": "16:90",
+          "jfr_pris": "55:56",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "snabbfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "salt",
+        "peppar",
+        "olivolja",
+        "vitlöksklyfta",
+        "sambal oelek",
+        "sweet chilisås",
+        "vitlöksklyfta",
+        "japansk soja",
+        "vatten",
+        "olja"
+      ],
+      "time": "PT45M",
+      "servings": "4",
+      "rating": 4.6,
+      "reviews": 8,
+      "nutrition": {
+        "calories": "578 calories",
+        "protein": "41 g",
+        "fat": "26 g",
+        "carbs": "41 g"
+      }
+    },
+    {
       "name": "Tacos i salladsblad med sojafärs och jordnötter",
       "url": "https://www.ica.se/recept/tacos-i-salladsblad-med-sojafars-och-jordnotter-728702/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234980/cf_259/tacos_i_salladsblad_med_sojafars_och_jordnotter.jpg",
@@ -58559,7 +60507,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -58737,36 +60685,36 @@
       }
     },
     {
-      "name": "Krämig gryta med kyckling och mango chutney",
-      "url": "https://www.ica.se/recept/kramig-gryta-med-kyckling-och-mango-chutney-728471/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_234348/cf_259/kramig_kycklinggryta_med_mango_chutney_.jpg",
+      "name": "Rostad potatis med krämig tonfiskröra",
+      "url": "https://www.ica.se/recept/rostad-potatis-med-kramig-tonfiskrora-729516/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246452/cf_259/rostad_potatis_med_kramig_tonfiskrora.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 16,
       "matched_count": 4,
       "match_percentage": 25.0,
       "matched_ingredients": [
         {
-          "ingredient": "honung",
-          "deal_name": "Blomsterhonung",
-          "deal_price": "55:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "55",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
+          "ingredient": "delikatesspotatis",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
           "deal_unit": null,
           "ord_pris": null,
           "jfr_pris": null,
-          "match_score": 1.0
+          "match_score": 0.9
         },
         {
-          "ingredient": "kycklingbuljongtärning",
+          "ingredient": "rödlök",
+          "deal_name": "SALLADSLÖK I KNIPPE",
+          "deal_price": "9.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "99:00",
+          "match_score": 0.85
+        },
+        {
+          "ingredient": "tonfisk buljong eller vatten",
           "deal_name": "Buljong",
           "deal_price": "30:-",
           "deal_store": "ICA Nära",
@@ -58776,39 +60724,39 @@
           "match_score": 0.9
         },
         {
-          "ingredient": "mango chutney",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "45,45",
+          "jfr_pris": "41,56",
           "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "ca 400 g rödkål",
-        "rödvinsvinäger",
+        "olja",
         "salt",
-        "olja",
         "peppar",
-        "ris eller annat gryn",
-        "snabbfiléer av kyckling",
+        "torkad timjan eller rosmarin",
+        "vitlöksklyfta",
+        "majonnäs",
+        "chilisås",
         "olja",
-        "curry",
-        "mjölk",
-        "majsstärkelse",
-        "färsk gräslök"
+        "vitvinsvinäger",
+        "dijonsenap",
+        "vatten",
+        "salladsmix"
       ],
       "time": "PT45M",
       "servings": "4",
-      "rating": 4.6,
-      "reviews": 110,
+      "rating": 4.5,
+      "reviews": 59,
       "nutrition": {
-        "calories": "722 calories",
-        "protein": "43 g",
-        "fat": "32 g",
-        "carbs": "64 g"
+        "calories": "683 calories",
+        "protein": "27 g",
+        "fat": "43 g",
+        "carbs": "44 g"
       }
     },
     {
@@ -59003,7 +60951,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -59068,12 +61016,12 @@
         },
         {
           "ingredient": "pkt fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         },
         {
@@ -59111,160 +61059,6 @@
         "protein": "",
         "fat": "",
         "carbs": ""
-      }
-    },
-    {
-      "name": "Ugnsbakad spätta med dill- och caviarsås",
-      "url": "https://www.ica.se/recept/ugnsbakad-spatta-med-dill-och-caviarsas-729550/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247911/cf_259/ugnsbakad_spatta_med_dill-_och_caviarsas .jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 18,
-      "matched_count": 4,
-      "match_percentage": 22.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "spättafilé eller alaska pollock",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fiskbuljong",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölig potatis",
-        "mjölk",
-        "salt",
-        "peppar",
-        "ättiksprit",
-        "strösocker",
-        "vatten",
-        "salt",
-        "vitpeppar",
-        "ca 2 dillvippor",
-        "majsstärkelse",
-        "färsk dill",
-        "röd caviar",
-        "spröd salladsmix"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "487 calories",
-        "protein": "43 g",
-        "fat": "12 g",
-        "carbs": "47 g"
-      }
-    },
-    {
-      "name": "Ugnsbakad spätta med dill- och caviarsås",
-      "url": "https://www.ica.se/recept/ugnsbakad-spatta-med-dill-och-caviarsas-729550/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_247911/cf_259/ugnsbakad_spatta_med_dill-_och_caviarsas .jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 18,
-      "matched_count": 4,
-      "match_percentage": 22.2,
-      "matched_ingredients": [
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "spättafilé eller alaska pollock",
-          "deal_name": "Läsk",
-          "deal_price": "30:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "24:90",
-          "jfr_pris": "10:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "fiskbuljong",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "matlagningsgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölig potatis",
-        "mjölk",
-        "salt",
-        "peppar",
-        "ättiksprit",
-        "strösocker",
-        "vatten",
-        "salt",
-        "vitpeppar",
-        "ca 2 dillvippor",
-        "majsstärkelse",
-        "färsk dill",
-        "röd caviar",
-        "spröd salladsmix"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "487 calories",
-        "protein": "43 g",
-        "fat": "12 g",
-        "carbs": "47 g"
       }
     },
     {
@@ -59308,12 +61102,12 @@
         },
         {
           "ingredient": "naturella, rostade cashewnötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -59346,14 +61140,34 @@
       }
     },
     {
-      "name": "Ärtig falafel med snabbsyrad rödlök",
-      "url": "https://www.ica.se/recept/artig-falafel-med-snabbsyrad-rodlok-721123/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_145939/cf_259/artig_falafel_med_snabbsyrad_rodlok.jpg",
+      "name": "Rostad sötpotatis med bönris och chilimajonnäs",
+      "url": "https://www.ica.se/recept/rostad-sotpotatis-med-bonris-och-chilimajonnas-729223/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241888/cf_259/rostad_sotpotatis_med_bonris_och_chilimajonnas.jpg",
       "category": "Huvudrätt,Middag",
       "total_ingredients": 19,
       "matched_count": 4,
       "match_percentage": 21.1,
       "matched_ingredients": [
+        {
+          "ingredient": "ca 600 g sötpotatis",
+          "deal_name": "Sötpotatis",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/kg",
+          "ord_pris": "49:95",
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majskorn",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
+        },
         {
           "ingredient": "gul lök",
           "deal_name": "SALLADSLÖK I KNIPPE",
@@ -59365,7 +61179,75 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "rödlök",
+          "ingredient": "färskpressad limejuice",
+          "deal_name": "Juice",
+          "deal_price": "40:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "49:90",
+          "jfr_pris": "20:00-22:86",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "olja",
+        "spiskummin",
+        "salt",
+        "peppar",
+        "vitlöksklyfta",
+        "olja",
+        "ris",
+        "kokta svarta bönor",
+        "skalet av 1 lime",
+        "bit rödkål",
+        "olja",
+        "riven ingefära",
+        "röd peppar",
+        "majonnäs",
+        "kruka koriander"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 13,
+      "nutrition": {
+        "calories": "826 calories",
+        "protein": "15 g",
+        "fat": "38 g",
+        "carbs": "99 g"
+      }
+    },
+    {
+      "name": "Sticky chicken med ris",
+      "url": "https://www.ica.se/recept/sticky-chicken-med-ris-729070/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_239245/cf_259/sticky_chicken_med_ris.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 19,
+      "matched_count": 4,
+      "match_percentage": 21.1,
+      "matched_ingredients": [
+        {
+          "ingredient": "hel färdiggrillad kyckling eller kyckling i ugn",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
+          "deal_store": "Willys",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "tunt skivade salladslökar",
           "deal_name": "SALLADSLÖK I KNIPPE",
           "deal_price": "9.90:-",
           "deal_store": "Willys",
@@ -59375,52 +61257,42 @@
           "match_score": 0.85
         },
         {
-          "ingredient": "små tortillabröd",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
+          "ingredient": "rostade vita sesamfrön",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "59,52",
+          "jfr_pris": "33,33",
           "match_score": 0.9
-        },
-        {
-          "ingredient": "avokado",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 1.0
         }
       ],
       "unmatched_ingredients": [
-        "vitlöksklyfta",
-        "groddade gula ärtor",
-        "finhackad persilja",
-        "malen spiskummin",
-        "torkad koriander",
-        "bakpulver",
-        "-  1 dl majsstärkelse",
-        "sambal oelek",
+        "ris",
+        "kålrabbi",
         "salt",
-        "olivolja",
-        "vit- eller rödvinsvinäger",
-        "salt",
-        "solrosskott",
-        "hummus",
-        "lime"
+        "socker",
+        "vitvins vinäger",
+        "sweet chilisås",
+        "ketchup",
+        "sesamolja",
+        "strösocker",
+        "riven vitlöksklyfta",
+        "vitvinsvinäger",
+        "kinesisk soja",
+        "finriven ingefära",
+        "vatten",
+        "ev färsk koriander"
       ],
-      "time": "PT90M",
+      "time": "PT45M",
       "servings": "4",
-      "rating": 4.5,
-      "reviews": 18,
+      "rating": 4.7,
+      "reviews": 187,
       "nutrition": {
-        "calories": "540 calories",
-        "protein": "11 g",
-        "fat": "27 g",
-        "carbs": "59 g"
+        "calories": "997 calories",
+        "protein": "64 g",
+        "fat": "44 g",
+        "carbs": "84 g"
       }
     },
     {
@@ -59435,7 +61307,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -59535,11 +61407,11 @@
         {
           "ingredient": "vitost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -59649,12 +61521,12 @@
       "matched_ingredients": [
         {
           "ingredient": "skivor cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -59704,12 +61576,12 @@
       "matched_ingredients": [
         {
           "ingredient": "skivor cheddarost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "CHEDDAR",
+          "deal_price": "139.90:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "139,90",
           "match_score": 0.9
         },
         {
@@ -59770,7 +61642,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -59825,12 +61697,12 @@
         },
         {
           "ingredient": "sats rostade grönsaker",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -60200,63 +62072,6 @@
       }
     },
     {
-      "name": "Quesadilla med skinka och mjukost med jalapeño",
-      "url": "https://www.ica.se/recept/quesadilla-med-skinka-och-mjukost-med-jalapeno-750030/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/przeb3qz6cr6glgssyvk.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 7,
-      "matched_count": 3,
-      "match_percentage": 42.9,
-      "matched_ingredients": [
-        {
-          "ingredient": "pressad skinka",
-          "deal_name": "STRIMLAD RÖKT SKINKA",
-          "deal_price": "19.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "110,56",
-          "match_score": 0.75
-        },
-        {
-          "ingredient": "mjukost hot jalapeño",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tortillabröd medium",
-          "deal_name": "Bröd",
-          "deal_price": "25:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "59,52",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "majskorn",
-        "salt",
-        "svartpeppar",
-        "matolja"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 5,
-      "nutrition": {
-        "calories": "931 calories",
-        "protein": "40 g",
-        "fat": "40 g",
-        "carbs": "99 g"
-      }
-    },
-    {
       "name": "Canard à l'orange",
       "url": "https://www.ica.se/recept/canard-a-lorange-750215/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/ltoehvocst8ipaumzpup.jpg",
@@ -60268,11 +62083,11 @@
         {
           "ingredient": "ankbröst , tinade frysta eller färska",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -60406,7 +62221,7 @@
           "deal_price": "20:-",
           "deal_store": "ICA Nära",
           "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
+          "ord_pris": "29:95-34:95",
           "jfr_pris": "133:33",
           "match_score": 0.9
         }
@@ -60518,12 +62333,12 @@
         },
         {
           "ingredient": "riven pecorinoost eller parmesanost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Parmesanost",
+          "deal_price": "45:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "300",
           "match_score": 0.9
         }
       ],
@@ -60601,124 +62416,6 @@
         "calories": "719 calories",
         "protein": "20 g",
         "fat": "43 g",
-        "carbs": "60 g"
-      }
-    },
-    {
-      "name": "Stekt kyckling med dipp på fetaost",
-      "url": "https://www.ica.se/recept/stekt-kyckling-med-dipp-pa-fetaost-726867/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_217878/cf_259/stekt_kyckling_med_dipp_pa_fetaost.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 9,
-      "matched_count": 3,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "snackpaprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "påse röd mangold",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "45,45",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ris eller annat gryn",
-        "smetana",
-        "peppar",
-        "snabbfiléer av kyckling",
-        "olja",
-        "salt"
-      ],
-      "time": "PT30M",
-      "servings": "2",
-      "rating": 4.6,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "695 calories",
-        "protein": "42 g",
-        "fat": "36 g",
-        "carbs": "51 g"
-      }
-    },
-    {
-      "name": "Gratinerad kyckling med grillad paprika",
-      "url": "https://www.ica.se/recept/gratinerad-kyckling-med-grillad-paprika-724360/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_186059/cf_259/gratinerad_kyckling_med_grillad_paprika.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 9,
-      "matched_count": 3,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "grillad paprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "crème fraiche fetaost & soltorkade tomater",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "påse mangold",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "45,45",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ris",
-        "snabbfiléer av kyckling",
-        "olja",
-        "salt",
-        "peppar",
-        "ask färsk persilja"
-      ],
-      "time": "PT30M",
-      "servings": "2",
-      "rating": 4.5,
-      "reviews": 28,
-      "nutrition": {
-        "calories": "684 calories",
-        "protein": "37 g",
-        "fat": "33 g",
         "carbs": "60 g"
       }
     },
@@ -60920,12 +62617,12 @@
         },
         {
           "ingredient": "ca 300 g rostas",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -60956,65 +62653,6 @@
         "protein": "43 g",
         "fat": "34 g",
         "carbs": "58 g"
-      }
-    },
-    {
-      "name": "Stekt kyckling med dipp på fetaost",
-      "url": "https://www.ica.se/recept/stekt-kyckling-med-dipp-pa-fetaost-726867/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_217878/cf_259/stekt_kyckling_med_dipp_pa_fetaost.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 9,
-      "matched_count": 3,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "snackpaprika",
-          "deal_name": "Röd spetspaprika i påse",
-          "deal_price": "18:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "26:95",
-          "jfr_pris": "90:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "påse röd mangold",
-          "deal_name": "Mango",
-          "deal_price": "30:-",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "45,45",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ris eller annat gryn",
-        "smetana",
-        "peppar",
-        "snabbfiléer av kyckling",
-        "olja",
-        "salt"
-      ],
-      "time": "PT30M",
-      "servings": "2",
-      "rating": 4.6,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "695 calories",
-        "protein": "42 g",
-        "fat": "36 g",
-        "carbs": "51 g"
       }
     },
     {
@@ -61077,65 +62715,6 @@
       }
     },
     {
-      "name": "Biff med rostad potatis och vitlökskräm",
-      "url": "https://www.ica.se/recept/biff-med-rostad-potatis-och-vitlokskram-726130/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_212506/cf_259/biff_med_rostad_potatis_och_vitlokskram.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 9,
-      "matched_count": 3,
-      "match_percentage": 33.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "delikatesspotatis",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "pärltomater",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "vitlöksklyfta",
-        "skivor ryggbiff",
-        "krispsallad"
-      ],
-      "time": "PT45M",
-      "servings": "2",
-      "rating": 4.5,
-      "reviews": 17,
-      "nutrition": {
-        "calories": "599 calories",
-        "protein": "35 g",
-        "fat": "29 g",
-        "carbs": "46 g"
-      }
-    },
-    {
       "name": "Moules frites",
       "url": "https://www.ica.se/recept/moules-frites-730142/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_251710/cf_259/moules_frites.jpg",
@@ -61146,12 +62725,12 @@
       "matched_ingredients": [
         {
           "ingredient": "pommes frites",
-          "deal_name": "Pommes Frites, Strips",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "28:95",
-          "jfr_pris": "15:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         },
         {
@@ -61277,7 +62856,7 @@
         {
           "ingredient": "lövbiff",
           "deal_name": "LÖVBIFF",
-          "deal_price": "Medlemspris",
+          "deal_price": "179:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -61286,12 +62865,12 @@
         },
         {
           "ingredient": "rostade sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -61346,12 +62925,12 @@
         },
         {
           "ingredient": "fetaost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
+          "deal_name": "Feta",
+          "deal_price": "40:-",
           "deal_store": "ICA Nära",
           "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "ord_pris": "31:95-33:95",
+          "jfr_pris": "153:85",
           "match_score": 0.9
         }
       ],
@@ -61556,66 +63135,6 @@
       }
     },
     {
-      "name": "Kycklingfilé med vitlökssås och klyftpotatis",
-      "url": "https://www.ica.se/recept/kycklingfile-med-vitlokssas-och-klyftpotatis-725259/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_198707/cf_259/kycklingfilé_med_vitlokssas_och_klyftpotatis.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 10,
-      "matched_count": 3,
-      "match_percentage": 30.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "crème fraiche",
-          "deal_name": "Crème Fraiche",
-          "deal_price": "24:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "15:90-22:90",
-          "jfr_pris": "60:00",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ca 600 g minutfilé av kyckling",
-        "marinad",
-        "olja",
-        "salt",
-        "peppar",
-        "vitlöksklyfta",
-        "isbergssallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 21,
-      "nutrition": {
-        "calories": "561 calories",
-        "protein": "30 g",
-        "fat": "23 g",
-        "carbs": "55 g"
-      }
-    },
-    {
       "name": "Kryddig kyckling med ajvaryoghurt",
       "url": "https://www.ica.se/recept/kryddig-kyckling-med-ajvaryoghurt-725242/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_197732/cf_259/kryddig_kyckling_med_ajvaryoghurt.jpg",
@@ -61687,7 +63206,7 @@
         {
           "ingredient": "ca 900 g kycklingben",
           "deal_name": "KYCKLINGBEN",
-          "deal_price": "Medlemspris",
+          "deal_price": "59.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -61808,7 +63327,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -61828,7 +63347,7 @@
         {
           "ingredient": "gurka",
           "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -61858,67 +63377,6 @@
       }
     },
     {
-      "name": "Tonfiskröra med curry och bakade potatisar",
-      "url": "https://www.ica.se/recept/tonfiskrora-med-curry-och-bakade-potatisar-726033/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_210659/cf_259/tonfiskrora_med_curry_och_bakade_potatisar.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 11,
-      "matched_count": 3,
-      "match_percentage": 27.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "delikatesspotatis",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tonfisk i vatten",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "majskorn",
-        "curry",
-        "smetana",
-        "chilisås",
-        "kruksallad"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 19,
-      "nutrition": {
-        "calories": "583 calories",
-        "protein": "28 g",
-        "fat": "29 g",
-        "carbs": "49 g"
-      }
-    },
-    {
       "name": "Amirs lax med brynt sojasmör och pak choi",
       "url": "https://www.ica.se/recept/amirs-lax-med-brynt-sojasmor-och-pak-choi-718054/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_101757/cf_259/amirs_lax_med_brynt_sojasmor_och_pak_choi.jpg",
@@ -61930,7 +63388,7 @@
         {
           "ingredient": "portionsbitar regnbågslax",
           "deal_name": "VARMRÖKT REGNBÅGSLAX",
-          "deal_price": "Medlemspris",
+          "deal_price": "119:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -62010,12 +63468,12 @@
         },
         {
           "ingredient": "hackade rostade nötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -62072,12 +63530,12 @@
         },
         {
           "ingredient": "hackade rostade nötter",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -62114,12 +63572,12 @@
       "matched_ingredients": [
         {
           "ingredient": "rostade salta mandlar",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         },
         {
@@ -62134,12 +63592,12 @@
         },
         {
           "ingredient": "hackade, rostade och saltade mandlar",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -62196,13 +63654,13 @@
         },
         {
           "ingredient": "kalkonbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         }
       ],
       "unmatched_ingredients": [
@@ -62258,13 +63716,13 @@
         },
         {
           "ingredient": "kalkonbacon",
-          "deal_name": "Bacon",
-          "deal_price": "Medlemspris",
-          "deal_store": "Stora Coop",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
+          "deal_name": "Bacon, Stekfläsk",
+          "deal_price": "115:-",
+          "deal_store": "ICA Supermarket",
+          "deal_unit": "/st",
+          "ord_pris": "159:00-175:00",
+          "jfr_pris": "115:00",
+          "match_score": 0.85
         }
       ],
       "unmatched_ingredients": [
@@ -62372,13 +63830,13 @@
         },
         {
           "ingredient": "skalade räkor",
-          "deal_name": "Räkor med skal 90/120",
-          "deal_price": "79:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "62:90",
-          "jfr_pris": "98:75",
-          "match_score": 0.85
+          "deal_name": "Handskalade räkor",
+          "deal_price": "89:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "370,83",
+          "match_score": 0.9
         },
         {
           "ingredient": "färskpressad limejuice",
@@ -62477,66 +63935,66 @@
       }
     },
     {
-      "name": "Rårakepizza med rökt lax",
-      "url": "https://www.ica.se/recept/rarakepizza-med-rokt-lax-729819/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248780/cf_259/rarakepizza_med_rokt_lax.jpg",
-      "category": "Brunch",
+      "name": "Sojaglacerad lax med gurksallad",
+      "url": "https://www.ica.se/recept/sojaglacerad-lax-med-gurksallad-729642/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248319/cf_259/sojaglacerad_lax_med_gurksallad.jpg",
+      "category": "Huvudrätt,Middag",
       "total_ingredients": 13,
       "matched_count": 3,
       "match_percentage": 23.1,
       "matched_ingredients": [
         {
-          "ingredient": "fast potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "tunt skivad rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
+          "ingredient": "gurka",
+          "deal_name": "HAMBURGERGURKA",
+          "deal_price": "23.90:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
+          "jfr_pris": null,
+          "match_score": 0.9
         },
         {
-          "ingredient": "smör",
-          "deal_name": "Smör",
-          "deal_price": "55:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "78:00",
-          "jfr_pris": "110:00",
-          "match_score": 1.0
+          "ingredient": "bitar laxfilé",
+          "deal_name": "Färsk laxfilé",
+          "deal_price": "149:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "149",
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "majsstärkelse",
+          "deal_name": "MAJS",
+          "deal_price": "19.95:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "41,56",
+          "match_score": 0.9
         }
       ],
       "unmatched_ingredients": [
-        "smetana",
-        "finriven pepparrot",
-        "finrivet  citronskal",
+        "ris",
+        "lime",
+        "sesamfrön",
         "salt",
-        "majsstärkelse",
-        "kallrökt lax",
-        "finskuren gräslök",
+        "peppar",
         "olja",
-        "svartpeppar",
-        "färsk dill"
+        "vitlöksklyfta",
+        "vatten",
+        "japansk soja",
+        "sweet chilisås"
       ],
-      "time": "PT45M",
+      "time": "PT30M",
       "servings": "4",
       "rating": 4.5,
-      "reviews": 25,
+      "reviews": 22,
       "nutrition": {
-        "calories": "322 calories",
-        "protein": "11 g",
-        "fat": "19 g",
-        "carbs": "26 g"
+        "calories": "575 calories",
+        "protein": "31 g",
+        "fat": "23 g",
+        "carbs": "59 g"
       }
     },
     {
@@ -62600,133 +64058,6 @@
         "protein": "33 g",
         "fat": "28 g",
         "carbs": "79 g"
-      }
-    },
-    {
-      "name": "Tomatsoppa med currystekt kyckling och paneer",
-      "url": "https://www.ica.se/recept/tomatsoppa-med-currystekt-kyckling-och-paneer-725813/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_203285/cf_259/tomatsoppa_med_currystekt_kyckling_och_paneer.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 3,
-      "match_percentage": 23.1,
-      "matched_ingredients": [
-        {
-          "ingredient": "kokosmjölk",
-          "deal_name": "LAKTOSFRI MJÖLK",
-          "deal_price": "42:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "kycklingbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "paneer ost",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "färsk riven ingefära",
-        "vitlöksklyfta",
-        "tomatsoppa",
-        "vatten",
-        "salt",
-        "svartpeppar",
-        "lime",
-        "ca 400 g currykryddade strimlor av kyckling",
-        "majsolja",
-        "kruka gräslök"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 17,
-      "nutrition": {
-        "calories": "548 calories",
-        "protein": "27 g",
-        "fat": "42 g",
-        "carbs": "16 g"
-      }
-    },
-    {
-      "name": "Torskgratäng med dillsås och pepparrotsgurka",
-      "url": "https://www.ica.se/recept/torskgratang-med-dillsas-och-pepparrotsgurka-729553/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248117/cf_259/fiskgratang_med_dill_och_pepparrotsgurka.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 3,
-      "match_percentage": 21.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatisar",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "vispgrädde",
-          "deal_name": "Vispgrädde",
-          "deal_price": "29:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "fiskbuljongtärning",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "mjölk",
-        "majsstärkelse",
-        "salt",
-        "peppar",
-        "färsk dill",
-        "torskfilé",
-        "snackgurka",
-        "riven pepparrot",
-        "citron",
-        "olivolja",
-        "hackad färsk dill"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 13,
-      "nutrition": {
-        "calories": "587 calories",
-        "protein": "35 g",
-        "fat": "30 g",
-        "carbs": "41 g"
       }
     },
     {
@@ -62855,6 +64186,70 @@
         "protein": "31 g",
         "fat": "50 g",
         "carbs": "9 g"
+      }
+    },
+    {
+      "name": "Kyckling i ajvar, syrad grädde och råmarinerad silverlök",
+      "url": "https://www.ica.se/recept/kyckling-i-ajvar-syrad-gradde-och-ramarinerad-silverlok-720736/",
+      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_150351/cf_259/kyckling_i_ajvar__syrad_gradde_och_ramarinerad_silverlok.jpg",
+      "category": "Huvudrätt,Middag",
+      "total_ingredients": 14,
+      "matched_count": 3,
+      "match_percentage": 21.4,
+      "matched_ingredients": [
+        {
+          "ingredient": "valnötter",
+          "deal_name": "TE",
+          "deal_price": "39:-",
+          "deal_store": "ICA Maxi",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
+          "match_score": 0.9
+        },
+        {
+          "ingredient": "minutfiléer av kyckling",
+          "deal_name": "Strimlad kyckling (Sverige/Guldfågeln)",
+          "deal_price": "79.9:-",
+          "deal_store": "Stora Coop Västberga",
+          "deal_unit": "st",
+          "ord_pris": null,
+          "jfr_pris": "133,17/kg.",
+          "match_score": 0.75
+        },
+        {
+          "ingredient": "sallad",
+          "deal_name": "Socker- och salladsärtor i påse",
+          "deal_price": "20:-",
+          "deal_store": "ICA Nära",
+          "deal_unit": "/st",
+          "ord_pris": "29:95-34:95",
+          "jfr_pris": "133:33",
+          "match_score": 0.9
+        }
+      ],
+      "unmatched_ingredients": [
+        "silverlök",
+        "vitvinsvinäger",
+        "olivolja",
+        "salt",
+        "svartpeppar",
+        "olivolja",
+        "ajvar relish",
+        "vatten",
+        "syrad grädde",
+        "kruka persilja",
+        "ris"
+      ],
+      "time": "PT30M",
+      "servings": "4",
+      "rating": 4.5,
+      "reviews": 44,
+      "nutrition": {
+        "calories": "631 calories",
+        "protein": "37 g",
+        "fat": "27 g",
+        "carbs": "59 g"
       }
     },
     {
@@ -63017,12 +64412,12 @@
         },
         {
           "ingredient": "rostade vita sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_name": "Rosta",
+          "deal_price": "15:-",
+          "deal_store": "ICA Kvantum",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": "33,33",
           "match_score": 0.9
         }
       ],
@@ -63049,71 +64444,6 @@
         "protein": "36 g",
         "fat": "67 g",
         "carbs": "59 g"
-      }
-    },
-    {
-      "name": "Glacerad kyckling med avokadoröra",
-      "url": "https://www.ica.se/recept/glacerad-kyckling-med-avokadorora-728976/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_240537/cf_259/glacerad_kyckling_med_avokadorora.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 15,
-      "matched_count": 3,
-      "match_percentage": 20.0,
-      "matched_ingredients": [
-        {
-          "ingredient": "potatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "plommontomater",
-          "deal_name": "Plommontomater",
-          "deal_price": "20:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "40",
-          "match_score": 1.0
-        },
-        {
-          "ingredient": "avokador",
-          "deal_name": "Avokado",
-          "deal_price": "20:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "2 för",
-          "ord_pris": "16:90",
-          "jfr_pris": "55:56",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "olivolja",
-        "vitlöksklyfta",
-        "sambal oelek",
-        "sweet chilisås",
-        "vitlöksklyfta",
-        "japansk soja",
-        "vatten",
-        "snabbfiléer av kyckling",
-        "olja"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.6,
-      "reviews": 8,
-      "nutrition": {
-        "calories": "578 calories",
-        "protein": "41 g",
-        "fat": "26 g",
-        "carbs": "41 g"
       }
     },
     {
@@ -63183,72 +64513,6 @@
       }
     },
     {
-      "name": "Rostad potatis med krämig tonfiskröra",
-      "url": "https://www.ica.se/recept/rostad-potatis-med-kramig-tonfiskrora-729516/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_246452/cf_259/rostad_potatis_med_kramig_tonfiskrora.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 16,
-      "matched_count": 3,
-      "match_percentage": 18.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "delikatesspotatis",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "rödlök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "tonfisk buljong eller vatten",
-          "deal_name": "Buljong",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "22:95",
-          "jfr_pris": "2:50",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "salt",
-        "peppar",
-        "torkad timjan eller rosmarin",
-        "vitlöksklyfta",
-        "majonnäs",
-        "chilisås",
-        "majskorn",
-        "olja",
-        "vitvinsvinäger",
-        "dijonsenap",
-        "vatten",
-        "salladsmix"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 59,
-      "nutrition": {
-        "calories": "683 calories",
-        "protein": "27 g",
-        "fat": "43 g",
-        "carbs": "44 g"
-      }
-    },
-    {
       "name": "Bulgursallad med halloumi",
       "url": "https://www.ica.se/recept/bulgursallad-med-halloumi-729971/",
       "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_250505/cf_259/bulgursallad_med_halloumi.jpg",
@@ -63280,11 +64544,11 @@
         {
           "ingredient": "halloumi eller grillost",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -63313,144 +64577,6 @@
         "protein": "18 g",
         "fat": "35 g",
         "carbs": "40 g"
-      }
-    },
-    {
-      "name": "Rostad sötpotatis med bönris och chilimajonnäs",
-      "url": "https://www.ica.se/recept/rostad-sotpotatis-med-bonris-och-chilimajonnas-729223/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_241888/cf_259/rostad_sotpotatis_med_bonris_och_chilimajonnas.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 19,
-      "matched_count": 3,
-      "match_percentage": 15.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "ca 600 g sötpotatis",
-          "deal_name": "Sötpotatis",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/kg",
-          "ord_pris": "49:95",
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "gul lök",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "färskpressad limejuice",
-          "deal_name": "Juice",
-          "deal_price": "40:-",
-          "deal_store": "ICA Supermarket",
-          "deal_unit": "/st",
-          "ord_pris": "49:90",
-          "jfr_pris": "20:00-22:86",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "olja",
-        "spiskummin",
-        "salt",
-        "peppar",
-        "majskorn",
-        "vitlöksklyfta",
-        "olja",
-        "ris",
-        "kokta svarta bönor",
-        "skalet av 1 lime",
-        "bit rödkål",
-        "olja",
-        "riven ingefära",
-        "röd peppar",
-        "majonnäs",
-        "kruka koriander"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 13,
-      "nutrition": {
-        "calories": "826 calories",
-        "protein": "15 g",
-        "fat": "38 g",
-        "carbs": "99 g"
-      }
-    },
-    {
-      "name": "Sticky chicken med ris",
-      "url": "https://www.ica.se/recept/sticky-chicken-med-ris-729070/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_239245/cf_259/sticky_chicken_med_ris.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 19,
-      "matched_count": 3,
-      "match_percentage": 15.8,
-      "matched_ingredients": [
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "tunt skivade salladslökar",
-          "deal_name": "SALLADSLÖK I KNIPPE",
-          "deal_price": "9.90:-",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "99:00",
-          "match_score": 0.85
-        },
-        {
-          "ingredient": "rostade vita sesamfrön",
-          "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ris",
-        "hel färdiggrillad kyckling eller kyckling i ugn",
-        "kålrabbi",
-        "salt",
-        "socker",
-        "vitvins vinäger",
-        "sweet chilisås",
-        "ketchup",
-        "sesamolja",
-        "strösocker",
-        "riven vitlöksklyfta",
-        "vitvinsvinäger",
-        "kinesisk soja",
-        "finriven ingefära",
-        "vatten",
-        "ev färsk koriander"
-      ],
-      "time": "PT45M",
-      "servings": "4",
-      "rating": 4.7,
-      "reviews": 187,
-      "nutrition": {
-        "calories": "997 calories",
-        "protein": "64 g",
-        "fat": "44 g",
-        "carbs": "84 g"
       }
     },
     {
@@ -63687,7 +64813,7 @@
         {
           "ingredient": "mozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -63831,7 +64957,7 @@
         {
           "ingredient": "buffelmozzarella",
           "deal_name": "MOZZARELLA",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Willys",
           "deal_unit": null,
           "ord_pris": null,
@@ -64028,7 +65154,7 @@
         {
           "ingredient": "gräddfil",
           "deal_name": "Gräddfil",
-          "deal_price": "Medlemspris",
+          "deal_price": "25:-",
           "deal_store": "Stora Coop",
           "deal_unit": null,
           "ord_pris": null,
@@ -64432,11 +65558,11 @@
         {
           "ingredient": "ostronsås",
           "deal_name": "Riven ost",
-          "deal_price": "30:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "2 för",
-          "ord_pris": "26:95",
-          "jfr_pris": "100:00",
+          "deal_price": "40:-",
+          "deal_store": "Stora Coop",
+          "deal_unit": null,
+          "ord_pris": null,
+          "jfr_pris": null,
           "match_score": 0.9
         }
       ],
@@ -64460,60 +65586,6 @@
         "calories": "639 calories",
         "protein": "35 g",
         "fat": "29 g",
-        "carbs": "59 g"
-      }
-    },
-    {
-      "name": "Sojaglacerad lax med gurksallad",
-      "url": "https://www.ica.se/recept/sojaglacerad-lax-med-gurksallad-729642/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_248319/cf_259/sojaglacerad_lax_med_gurksallad.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 13,
-      "matched_count": 2,
-      "match_percentage": 15.4,
-      "matched_ingredients": [
-        {
-          "ingredient": "gurka",
-          "deal_name": "HAMBURGERGURKA",
-          "deal_price": "Medlemspris",
-          "deal_store": "Willys",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "bitar laxfilé",
-          "deal_name": "Färsk laxfilé",
-          "deal_price": "149:-",
-          "deal_store": "ICA Kvantum",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": "149",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "ris",
-        "lime",
-        "sesamfrön",
-        "salt",
-        "peppar",
-        "olja",
-        "vitlöksklyfta",
-        "vatten",
-        "majsstärkelse",
-        "japansk soja",
-        "sweet chilisås"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 22,
-      "nutrition": {
-        "calories": "575 calories",
-        "protein": "31 g",
-        "fat": "23 g",
         "carbs": "59 g"
       }
     },
@@ -64624,61 +65696,6 @@
         "protein": "40 g",
         "fat": "47 g",
         "carbs": "43 g"
-      }
-    },
-    {
-      "name": "Kyckling i ajvar, syrad grädde och råmarinerad silverlök",
-      "url": "https://www.ica.se/recept/kyckling-i-ajvar-syrad-gradde-och-ramarinerad-silverlok-720736/",
-      "image": "https://assets.icanet.se/t_ICAseAbsoluteUrl/imagevaultfiles/id_150351/cf_259/kyckling_i_ajvar__syrad_gradde_och_ramarinerad_silverlok.jpg",
-      "category": "Huvudrätt,Middag",
-      "total_ingredients": 14,
-      "matched_count": 2,
-      "match_percentage": 14.3,
-      "matched_ingredients": [
-        {
-          "ingredient": "valnötter",
-          "deal_name": "TE",
-          "deal_price": "39:-",
-          "deal_store": "ICA Maxi",
-          "deal_unit": null,
-          "ord_pris": null,
-          "jfr_pris": null,
-          "match_score": 0.9
-        },
-        {
-          "ingredient": "sallad",
-          "deal_name": "Socker- och salladsärtor i påse",
-          "deal_price": "20:-",
-          "deal_store": "ICA Nära",
-          "deal_unit": "/st",
-          "ord_pris": "34:95-36:95",
-          "jfr_pris": "133:33",
-          "match_score": 0.9
-        }
-      ],
-      "unmatched_ingredients": [
-        "silverlök",
-        "vitvinsvinäger",
-        "olivolja",
-        "salt",
-        "svartpeppar",
-        "minutfiléer av kyckling",
-        "olivolja",
-        "ajvar relish",
-        "vatten",
-        "syrad grädde",
-        "kruka persilja",
-        "ris"
-      ],
-      "time": "PT30M",
-      "servings": "4",
-      "rating": 4.5,
-      "reviews": 44,
-      "nutrition": {
-        "calories": "631 calories",
-        "protein": "37 g",
-        "fat": "27 g",
-        "carbs": "59 g"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Add `scrape_coop_se()` function to fetch deals from coop.se API for store-specific Coop pages
- Fix medlemspris bug that was discarding real prices when "Medlemspris" was detected
- Update STORES list to use coop.se URLs for Stora Coop Västberga and Coop Fruängen

## Before/After

| Store | Images | Descriptions | Prices |
|-------|--------|--------------|--------|
| Stora Coop Västberga | 0% → 100% | 0% → 100% | 78% → 100% |
| Coop Fruängen | 0% → 100% | 0% → 100% | 73% → 100% |

## Context
ereklamblad uses "paged-publications" format for store-specific pages (digitized flyer scans with hotspots) which lacks image/description data. coop.se has a public API at `external.api.coop.se/dke/offers/{store_id}` that returns structured offer data with full images, descriptions, and prices.

## Test plan
- [ ] Run `python scrape_deals.py` and verify Coop stores have images
- [ ] Check deals.json for store-specific Coop entries
- [ ] Run `python match_recipes.py` to verify matching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)